### PR TITLE
Query command, better promise handling

### DIFF
--- a/src/client/api/RestClient.js
+++ b/src/client/api/RestClient.js
@@ -57,22 +57,27 @@ class RestClient {
       .then(JSON.parse)
   }
 
+  query (queryString: string): Promise<Object> {
+    return unpack(this.postRequest('query', queryString, false))
+      .then(JSON.parse)
+  }
+
   getStatus (): Promise<NodeStatus> {
-    return unpack(this.getRequest('/status'))
+    return unpack(this.getRequest('status'))
       .then(validateStatus)
   }
 
   setStatus (status: NodeStatus): Promise<NodeStatus> {
-    return unpack(this.postRequest(`/status/${status}`, '', false))
+    return unpack(this.postRequest(`status/${status}`, '', false))
       .then(validateStatus)
   }
 
   getDirectoryId (): Promise<string> {
-    return unpack(this.getRequest('/config/dir'))
+    return unpack(this.getRequest('config/dir'))
   }
 
   setDirectoryId (id: string): Promise<boolean> {
-    return unpack(this.postRequest('/config/dir', id, false))
+    return unpack(this.postRequest('config/dir', id, false))
       .then(() => true)
   }
 }

--- a/src/client/cli/commands/query.js
+++ b/src/client/cli/commands/query.js
@@ -1,0 +1,18 @@
+// @flow
+
+const RestClient = require('../../api/RestClient')
+
+module.exports = {
+  command: 'query [queryString]',
+  description: 'send a mediachain query to the node for evaluation.',
+  handler: (opts: {peerUrl: string, queryString: string}) => {
+    const {peerUrl, queryString} = opts
+
+    const client = new RestClient({peerUrl})
+    client.query(queryString)
+      .then(
+        response => console.dir(response, {colors: true}),
+        err => console.error(err.message)
+      )
+  }
+}


### PR DESCRIPTION
adds a new `query` command that accepts a query string and sends it over the HTTP api.

also cleans up the awkward promise handling in RestClient