### PR TITLE
Ingestion scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ jspm_packages
 .node_repl_history
 
 lib/
+
+# emacs backups
+*~

--- a/scripts/dataset-fetch.py
+++ b/scripts/dataset-fetch.py
@@ -40,7 +40,7 @@ def wget(cfg, batch, index):
 
 def zcat(cfg, batch, index):
     chunks = [os.path.join(cfg.dataset, os.path.basename(chunk)) for chunk in batch]
-    batchf = os.path.join(cfg.dataset, "batch_%d" % index)
+    batchf = os.path.join(cfg.dataset, "batch_%d.json" % index)
     with open(batchf, 'w') as out:
         p = subprocess.Popen(["zcat"] + chunks, stdout = out)
         rc = p.wait()

--- a/scripts/dataset-fetch.py
+++ b/scripts/dataset-fetch.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+
+import sys
+import os
+import argparse
+import subprocess
+
+def go(cfg):
+    with open("%s.manifest" % cfg.dataset) as mf:
+        chunks = [line.strip() for line in mf.readlines()]
+    chunks = chunks[cfg.start:]
+
+    if cfg.count > 0:
+        chunks = chunks[:cfg.count]
+
+    try:
+        os.mkdir(cfg.dataset, 0755)
+    except OSError as e:
+        print e.strerror
+    
+    index = cfg.start
+    while len(chunks) > 0:
+        batch = chunks[:cfg.batch]
+        fetch(cfg, batch, index)
+        chunks = chunks[cfg.batch:]
+        index += len(batch)
+
+def fetch(cfg, batch, index):
+    wget(cfg, batch, index)
+
+def wget(cfg, batch, index):
+    print "Fetching batch %d" % index
+    urls = [cfg.url + chunk for chunk in batch]
+    p = subprocess.Popen(["wget", "-P", cfg.dataset] + urls)
+    rc = p.wait()
+    if rc != 0:
+        raise Exception("Error fetching data: wget exit code %d" % rc)
+
+    
+def main(args):
+    parser = argparse.ArgumentParser(
+        prog = "dataset-fetch.py",
+        description = "fetch (part of) a dataset and prepare it for ingestion")
+
+    parser.add_argument('-b', '--batch',
+                        type = int,
+                        default = 100,
+                        dest = 'batch',
+                        help = "Number of chunks on each worker batch")
+    parser.add_argument('-c', '--count',
+                        type = int,
+                        default = 0,
+                        dest = 'count',
+                        help = "How many chunks to fetch; 0 will fetch the entire dataset")
+    parser.add_argument('-s', '--start',
+                        type = int,
+                        default = 0,
+                        dest = 'start',
+                        help = "Start index in the manifest")
+    parser.add_argument('dataset',
+                        type = str,
+                        help = "Name of the dataset")
+    parser.add_argument('url',
+                        type = str,
+                        help = "Base URL for dataset chunks")
+    cfg = parser.parse_args(args)
+    go(cfg)
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/scripts/ingest-parallel.py
+++ b/scripts/ingest-parallel.py
@@ -8,6 +8,7 @@ import argparse
 import tempfile
 import shutil
 import glob
+import multiprocessing
 
 def ingest(ns):
     procs = dict()
@@ -42,15 +43,17 @@ def ingest(ns):
         reap_some()
 
 def main(args):
+    ncpus = multiprocessing.cpu_count()
+    
     parser = argparse.ArgumentParser(
         prog = "ingest-parallel.py",
         description = "ingest a dir of ndjson files in parallel"
     )
     parser.add_argument('-n', '--processes',
                         type = int,
-                        default = 10,
+                        default = ncpus,
                         dest = 'procs',
-                        help = "Number of parallel ingestion processes")
+                        help = "Number of parallel ingestion processes; defaults to number of cpus")
     parser.add_argument('script',
                         type = str,
                         help = "Ingest script; must accept ndjson filname")

--- a/scripts/publish-500px.sh
+++ b/scripts/publish-500px.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+NAMESPACE="images.500px"
+CONTENT_SELECTOR="--contentSelector _source"
+CONTENT_FILTERS="--contentFilters aesthetics"
+ID_SELECTOR="--idSelector native_id"
+
+mcclient publish ${CONTENT_SELECTOR} ${ID_SELECTOR} ${CONTENT_FILTERS} ${NAMESPACE} $1 > /dev/null
+

--- a/scripts/publish-dpla.sh
+++ b/scripts/publish-dpla.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
 NAMESPACE="images.dpla"
+REGEX="(dpla_)http.*/(.*)"
 CONTENT_SELECTOR="--contentSelector _source"
 ID_SELECTOR="--idSelector native_id"
-ID_REGEXP="--idRegex '(dpla_)http.*/(.*)'"
+ID_REGEXP="--idRegex $REGEX"
 CONTENT_FILTERS="--contentFilters aesthetics"
 
-mcclient publish --dryRun ${CONTENT_SELECTOR} ${ID_SELECTOR} ${ID_REGEXP} ${CONTENT_FILTERS} ${NAMESPACE} $1 > /dev/null
+mcclient publish ${CONTENT_SELECTOR} ${ID_SELECTOR} ${ID_REGEXP} ${CONTENT_FILTERS} ${NAMESPACE} $1 > /dev/null
 

--- a/scripts/publish-dpla.sh
+++ b/scripts/publish-dpla.sh
@@ -3,9 +3,9 @@
 NAMESPACE="images.dpla"
 REGEX="(dpla_)http.*/(.*)"
 CONTENT_SELECTOR="--contentSelector _source"
+CONTENT_FILTERS="--contentFilters aesthetics"
 ID_SELECTOR="--idSelector native_id"
 ID_REGEXP="--idRegex $REGEX"
-CONTENT_FILTERS="--contentFilters aesthetics"
 
 mcclient publish ${CONTENT_SELECTOR} ${ID_SELECTOR} ${ID_REGEXP} ${CONTENT_FILTERS} ${NAMESPACE} $1 > /dev/null
 

--- a/scripts/publish-dpla.sh
+++ b/scripts/publish-dpla.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+NAMESPACE="images.dpla"
+CONTENT_SELECTOR="--contentSelector _source"
+ID_SELECTOR="--idSelector native_id"
+ID_REGEXP="--idRegex '(dpla_)http.*/(.*)'"
+CONTENT_FILTERS="--contentFilters aesthetics"
+
+mcclient publish --dryRun ${CONTENT_SELECTOR} ${ID_SELECTOR} ${ID_REGEXP} ${CONTENT_FILTERS} ${NAMESPACE} $1 > /dev/null
+

--- a/scripts/publish-flickr.sh
+++ b/scripts/publish-flickr.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+NAMESPACE="images.flickr"
+CONTENT_SELECTOR="--contentSelector _source"
+CONTENT_FILTERS="--contentFilters aesthetics"
+ID_SELECTOR="--idSelector native_id"
+
+mcclient publish ${CONTENT_SELECTOR} ${ID_SELECTOR} ${CONTENT_FILTERS} ${NAMESPACE} $1 > /dev/null
+

--- a/scripts/publish-pexels.sh
+++ b/scripts/publish-pexels.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+NAMESPACE="images.pexels"
+CONTENT_SELECTOR="--contentSelector _source"
+CONTENT_FILTERS="--contentFilters aesthetics"
+ID_SELECTOR="--idSelector native_id"
+
+mcclient publish ${CONTENT_SELECTOR} ${ID_SELECTOR} ${CONTENT_FILTERS} ${NAMESPACE} $1 > /dev/null
+

--- a/src/client/cli/commands/publish.js
+++ b/src/client/cli/commands/publish.js
@@ -82,9 +82,7 @@ module.exports = {
         for (let filter of contentFilters) {
           objectPath.del(obj, filter)
         }
-        console.log('filtered: ')
-        console.dir(obj, {colors: true, depth: 1000})
-
+          
         let id = objectPath.get(obj, idSelector)
         if (idRegex != null) {
           id = extractId(id, idRegex)


### PR DESCRIPTION
- modify ingest-parallel to spawn as many workers as cpus by default.
- add publish scripts for ingesting our datasets
   - publish-dpla.sh for DPLA
- add a dataset-fetch script to download (parts of) a dataset starting from a manifest file, and batch it for execution by ingestion workers.
- fix leftover debugging prints in publish.js

TBD: scripts for our other seed datasets