### PR TITLE
Update client with missing concat functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ directly instead.
 `mcclient` contains several sub-commands, so the general invocation is
 `mcclient [global-options] <command> [command-options]`.
 
-At the moment, the only global option is `--peerUrl` or `-p`, which sets the location of the remote node's
+At the moment, the only global option is `--apiUrl` or `-p`, which sets the location of the remote node's
 HTTP API. By default, `mcclient` will attempt to connect to a concat node running on localhost at port 9002,
 which is concat's default listen address for the HTTP API.  If you've configured concat to run on a different
 port or on a remote machine, use the `-p` flag to pass in a new URL, e.g. `mcclient -p http://localhost:5678 id`

--- a/integration-test/index.js
+++ b/integration-test/index.js
@@ -7,7 +7,7 @@ const RestClient = require('../src/client/api/RestClient')
 
 describe('crazy docker integration setup', () => {
   it('can contact a node using a docker-compose service name as hostname', () => {
-    const client = new RestClient({peerUrl: 'http://mcnode:9002'})
+    const client = new RestClient({apiUrl: 'http://mcnode:9002'})
     return client.id().then(id => {
       assert(id != null, 'should be able to get node id')
     })

--- a/integration-test/util.js
+++ b/integration-test/util.js
@@ -55,7 +55,7 @@ function concatNodePeerId (): PeerId {
 
 function concatNodeClient (): Promise<RestClient> {
   return dnsLookup(NODE_HOSTNAME)
-    .then(ipAddr => new RestClient({peerUrl: `http://${ipAddr}:${NODE_API_PORT}`}))
+    .then(ipAddr => new RestClient({apiUrl: `http://${ipAddr}:${NODE_API_PORT}`}))
 }
 
 function setConcatNodeDirectoryInfo (): Promise<*> {

--- a/src/client/api/RestClient.js
+++ b/src/client/api/RestClient.js
@@ -85,8 +85,12 @@ class RestClient {
     })
   }
 
-  id (): Promise<Object> {
-    return this.getRequest('id')
+  id (peerId?: string): Promise<Object> {
+    let path = 'id'
+    if (peerId != null) {
+      path += '/' + peerId
+    }
+    return this.getRequest(path)
       .then(r => r.json())
   }
 

--- a/src/client/api/RestClient.js
+++ b/src/client/api/RestClient.js
@@ -111,13 +111,17 @@ class RestClient {
       .then(r => r.json())
   }
 
-  query (queryString: string): Promise<Array<Object>> {
-    return this.queryStream(queryString)
+  query (queryString: string, remotePeer?: string): Promise<Array<Object>> {
+    return this.queryStream(queryString, remotePeer)
       .then(r => r.values())
   }
 
-  queryStream (queryString: string): Promise<NDJsonResponse> {
-    return this.postRequest('query', queryString, false)
+  queryStream (queryString: string, remotePeer?: string): Promise<NDJsonResponse> {
+    let path = 'query'
+    if (remotePeer != null) {
+      path += '/' + remotePeer
+    }
+    return this.postRequest(path, queryString, false)
       .then(r => new NDJsonResponse(r))
   }
 

--- a/src/client/api/RestClient.js
+++ b/src/client/api/RestClient.js
@@ -219,6 +219,18 @@ class RestClient {
     return this.postRequest('config/info', info, false)
       .then(r => r.text())
   }
+
+  getNATConfig (): Promise<string> {
+    return this.getRequest('config/nat')
+      .then(r => r.text())
+      .then(s => s.trim())
+  }
+
+  setNATConfig (config: string): Promise<boolean> {
+    return this.postRequest('config/nat', config, false)
+      .then(r => r.text())
+      .then(s => s.trim() === 'OK')
+  }
 }
 
 function validateStatus (status: string): NodeStatus {

--- a/src/client/api/RestClient.js
+++ b/src/client/api/RestClient.js
@@ -125,6 +125,18 @@ class RestClient {
       .then(r => new NDJsonResponse(r))
   }
 
+  merge (queryString: string, remotePeer: string): Promise<{statementCount: number, objectCount: number}> {
+    return this.postRequest(`merge/${remotePeer}`, queryString, false)
+      .then(r => r.text())
+      .then(resp => {
+        const counts = resp.split('\n')
+          .filter(line => line.length > 0)
+          .map(line => Number.parseInt(line))
+        const [statementCount, objectCount] = counts
+        return {statementCount, objectCount}
+      })
+  }
+
   delete (queryString: string): Promise<number> {
     return this.postRequest('delete', queryString, false)
       .then(r => r.text())

--- a/src/client/api/RestClient.js
+++ b/src/client/api/RestClient.js
@@ -50,16 +50,16 @@ class RestError extends Error {
 }
 
 class RestClient {
-  peerUrl: string;
+  apiUrl: string;
   client: Function;
 
-  constructor (options: {peerUrl?: string}) {
-    this.peerUrl = options.peerUrl || ''
+  constructor (options: {apiUrl?: string}) {
+    this.apiUrl = options.apiUrl || ''
   }
 
   _makeUrl (path: string): string {
     const absPath = path.startsWith('/') ? path : '/' + path
-    return this.peerUrl + absPath
+    return this.apiUrl + absPath
   }
 
   req (path: string, args: Object = {}): Promise<FetchResponse> {

--- a/src/client/api/RestClient.js
+++ b/src/client/api/RestClient.js
@@ -208,6 +208,17 @@ class RestClient {
     return this.postRequest('config/dir', id, false)
       .then(() => true)
   }
+
+  getInfo (): Promise<string> {
+    return this.getRequest('config/info')
+      .then(r => r.text())
+      .then(r => r.trim())
+  }
+
+  setInfo (info: string): Promise<string> {
+    return this.postRequest('config/info', info, false)
+      .then(r => r.text())
+  }
 }
 
 function validateStatus (status: string): NodeStatus {

--- a/src/client/api/RestClient.js
+++ b/src/client/api/RestClient.js
@@ -161,6 +161,12 @@ class RestClient {
       })
   }
 
+  listPeers (): Promise<Array<string>> {
+    return this.getRequest('dir/list')
+      .then(r => r.text())
+      .then(s => s.split('\n').filter(line => line.length > 0))
+  }
+
   getStatus (): Promise<NodeStatus> {
     return this.getRequest('status')
       .then(r => r.text())

--- a/src/client/cli/commands/config/dir.js
+++ b/src/client/cli/commands/config/dir.js
@@ -5,9 +5,9 @@ const RestClient = require('../../../api/RestClient')
 module.exports = {
   command: 'dir [dirId]',
   description: 'get or set the directory server id',
-  handler: (opts: {peerUrl: string, dirId?: string}) => {
-    const {peerUrl, dirId} = opts
-    const client = new RestClient({peerUrl})
+  handler: (opts: {apiUrl: string, dirId?: string}) => {
+    const {apiUrl, dirId} = opts
+    const client = new RestClient({apiUrl})
     if (dirId) {
       client.setDirectoryId(dirId)
         .then(() => {

--- a/src/client/cli/commands/config/info.js
+++ b/src/client/cli/commands/config/info.js
@@ -1,0 +1,24 @@
+// @flow
+
+const RestClient = require('../../../api/RestClient')
+
+module.exports = {
+  command: 'info [peerInfo]',
+  description: 'get or set the peer info message',
+  handler: (opts: {peerUrl: string, peerInfo?: string}) => {
+    const {peerUrl, peerInfo} = opts
+    const client = new RestClient({peerUrl})
+    if (peerInfo) {
+      client.setInfo(peerInfo)
+        .then(() => {
+          console.log(`set peer info to "${peerInfo}"`)
+        })
+    } else {
+      return client.getInfo()
+        .then(
+          console.log,
+          err => console.error(err.message)
+        )
+    }
+  }
+}

--- a/src/client/cli/commands/config/info.js
+++ b/src/client/cli/commands/config/info.js
@@ -5,9 +5,9 @@ const RestClient = require('../../../api/RestClient')
 module.exports = {
   command: 'info [peerInfo]',
   description: 'get or set the peer info message',
-  handler: (opts: {peerUrl: string, peerInfo?: string}) => {
-    const {peerUrl, peerInfo} = opts
-    const client = new RestClient({peerUrl})
+  handler: (opts: {apiUrl: string, peerInfo?: string}) => {
+    const {apiUrl, peerInfo} = opts
+    const client = new RestClient({apiUrl})
     if (peerInfo) {
       client.setInfo(peerInfo)
         .then(() => {

--- a/src/client/cli/commands/config/nat.js
+++ b/src/client/cli/commands/config/nat.js
@@ -1,0 +1,27 @@
+// @flow
+
+const RestClient = require('../../../api/RestClient')
+
+module.exports = {
+  command: 'nat [natConfig]',
+  description: `get or set the NAT configuration. Valid settings are 'none', 'auto', '*', '*:port', 'ip:port' \n`,
+  handler: (opts: {apiUrl: string, natConfig?: string}) => {
+    const {apiUrl, natConfig} = opts
+    const client = new RestClient({apiUrl})
+    if (natConfig) {
+      client.setNATConfig(natConfig)
+        .then(() => {
+          console.log(`set NAT configuration to "${natConfig}"`)
+        })
+        .catch(err => {
+          console.error('Error setting NAT configuration: ', err.message)
+        })
+    } else {
+      return client.getNATConfig()
+        .then(
+          console.log,
+          err => console.error(err.message)
+        )
+    }
+  }
+}

--- a/src/client/cli/commands/getData.js
+++ b/src/client/cli/commands/getData.js
@@ -6,9 +6,9 @@ module.exports = {
   command: 'getData <objectId>',
   description: 'request the object with objectId from the remote node and print to the console\n',
 
-  handler: (opts: {peerUrl: string, objectId: string}) => {
-    const {peerUrl, objectId} = opts
-    const client = new RestClient({peerUrl})
+  handler: (opts: {apiUrl: string, objectId: string}) => {
+    const {apiUrl, objectId} = opts
+    const client = new RestClient({apiUrl})
 
     client.getData(objectId)
       .then(

--- a/src/client/cli/commands/id.js
+++ b/src/client/cli/commands/id.js
@@ -6,9 +6,9 @@ module.exports = {
   command: 'id [peerId]',
   description: 'request the peer ids of the connected peer, ' +
     'or a different peer if peerId is given and a directory server is connected\n',
-  handler: (opts: {peerUrl: string, peerId?: string}) => {
-    const {peerUrl, peerId} = opts
-    const client = new RestClient({peerUrl})
+  handler: (opts: {apiUrl: string, peerId?: string}) => {
+    const {apiUrl, peerId} = opts
+    const client = new RestClient({apiUrl})
     client.id(peerId).then(
       printIds,
       err => { console.error(err.message) }

--- a/src/client/cli/commands/id.js
+++ b/src/client/cli/commands/id.js
@@ -3,10 +3,11 @@
 const RestClient = require('../../api/RestClient')
 
 module.exports = {
-  command: 'id',
-  description: 'request the peer id of the connected peer\n',
-  handler: (opts: {peerUrl: string}) => {
-    const {peerUrl} = opts
+  command: 'id [peerId]',
+  description: 'request the peer ids of the connected peer, ' +
+    'or a different peer if peerId is given and a directory server is connected\n',
+  handler: (opts: {peerUrl: string, peerId?: string}) => {
+    const {peerUrl, peerId} = opts
     const client = new RestClient({peerUrl})
     client.id().then(
       response => { console.log(response) },

--- a/src/client/cli/commands/id.js
+++ b/src/client/cli/commands/id.js
@@ -9,9 +9,16 @@ module.exports = {
   handler: (opts: {peerUrl: string, peerId?: string}) => {
     const {peerUrl, peerId} = opts
     const client = new RestClient({peerUrl})
-    client.id().then(
-      response => { console.log(response) },
+    client.id(peerId).then(
+      printIds,
       err => { console.error(err.message) }
     )
   }
+}
+
+function printIds (opts: {peer: string, publisher: string, info: string}) {
+  const {peer, publisher, info} = opts
+  console.log(`Peer ID: ${peer}`)
+  console.log(`Publisher ID: ${publisher}`)
+  console.log(`Info: ${info}`)
 }

--- a/src/client/cli/commands/listPeers.js
+++ b/src/client/cli/commands/listPeers.js
@@ -5,9 +5,9 @@ const RestClient = require('../../api/RestClient')
 module.exports = {
   command: 'listPeers',
   description: `fetch a list of peers from the node's directory server.\n`,
-  handler: (opts: {peerUrl: string}) => {
-    const {peerUrl} = opts
-    const client = new RestClient({peerUrl})
+  handler: (opts: {apiUrl: string}) => {
+    const {apiUrl} = opts
+    const client = new RestClient({apiUrl})
     client.listPeers().then(
       peers => { peers.forEach(p => console.log(p)) },
       err => { console.error(err.message) }

--- a/src/client/cli/commands/listPeers.js
+++ b/src/client/cli/commands/listPeers.js
@@ -1,0 +1,16 @@
+// @flow
+
+const RestClient = require('../../api/RestClient')
+
+module.exports = {
+  command: 'listPeers',
+  description: `fetch a list of peers from the node's directory server.\n`,
+  handler: (opts: {peerUrl: string}) => {
+    const {peerUrl} = opts
+    const client = new RestClient({peerUrl})
+    client.listPeers().then(
+      peers => { peers.forEach(p => console.log(p)) },
+      err => { console.error(err.message) }
+    )
+  }
+}

--- a/src/client/cli/commands/merge.js
+++ b/src/client/cli/commands/merge.js
@@ -1,0 +1,22 @@
+// @flow
+
+const RestClient = require('../../api/RestClient')
+
+module.exports = {
+  command: 'merge <remotePeer> <queryString>',
+  description: 'send a mediachain query to the node for evaluation.\n',
+  handler: (opts: {peerUrl: string, queryString: string, remotePeer: string}) => {
+    const {peerUrl, queryString, remotePeer} = opts
+
+    const client = new RestClient({peerUrl})
+    client.merge(queryString, remotePeer)
+      .then(({statementCount, objectCount}) => {
+        console.log(`merged ${statementCount} statements and ${objectCount} objects`)
+      })
+      .catch(err => console.error(err.message))
+  }
+}
+
+function printValue (obj: Object) {
+  console.dir(obj, {colors: true, depth: 100})
+}

--- a/src/client/cli/commands/merge.js
+++ b/src/client/cli/commands/merge.js
@@ -11,12 +11,14 @@ module.exports = {
     const client = new RestClient({peerUrl})
     client.merge(queryString, remotePeer)
       .then(({statementCount, objectCount}) => {
-        console.log(`merged ${statementCount} statements and ${objectCount} objects`)
+        console.log(`merged ${countString(statementCount, 'statement')} and ${countString(objectCount, 'object')}`)
       })
       .catch(err => console.error(err.message))
   }
 }
 
-function printValue (obj: Object) {
-  console.dir(obj, {colors: true, depth: 100})
+function countString (count: number, word: string): string {
+  let plural = word
+  if (count !== 1) plural += 's'
+  return count.toString() + ' ' + plural
 }

--- a/src/client/cli/commands/merge.js
+++ b/src/client/cli/commands/merge.js
@@ -5,10 +5,10 @@ const RestClient = require('../../api/RestClient')
 module.exports = {
   command: 'merge <remotePeer> <queryString>',
   description: 'send a mediachain query to the node for evaluation.\n',
-  handler: (opts: {peerUrl: string, queryString: string, remotePeer: string}) => {
-    const {peerUrl, queryString, remotePeer} = opts
+  handler: (opts: {apiUrl: string, queryString: string, remotePeer: string}) => {
+    const {apiUrl, queryString, remotePeer} = opts
 
-    const client = new RestClient({peerUrl})
+    const client = new RestClient({apiUrl})
     client.merge(queryString, remotePeer)
       .then(({statementCount, objectCount}) => {
         console.log(`merged ${countString(statementCount, 'statement')} and ${countString(objectCount, 'object')}`)

--- a/src/client/cli/commands/ping.js
+++ b/src/client/cli/commands/ping.js
@@ -5,11 +5,11 @@ const RestClient = require('../../api/RestClient')
 module.exports = {
   command: 'ping <peerId>',
   describe: 'ping a remote node\n',
-  handler: (opts: {peerId: string, peerUrl: string}) => {
-    const {peerId, peerUrl} = opts
+  handler: (opts: {peerId: string, apiUrl: string}) => {
+    const {peerId, apiUrl} = opts
     console.log('pinging peer: ', peerId)
 
-    const client = new RestClient({peerUrl})
+    const client = new RestClient({apiUrl})
     client.ping(peerId)
       .then(
         success => console.log(`ping OK`),

--- a/src/client/cli/commands/publish.js
+++ b/src/client/cli/commands/publish.js
@@ -11,7 +11,7 @@ const BATCH_SIZE = 1000
 
 type HandlerOptions = {
   namespace: string,
-  peerUrl: string,
+  apiUrl: string,
   idSelector: string,
   contentSelector: ?string,
   filename: ?string,
@@ -53,14 +53,14 @@ module.exports = {
   },
 
   handler: (opts: HandlerOptions) => {
-    const {namespace, peerUrl, batchSize, filename, dryRun} = opts
+    const {namespace, apiUrl, batchSize, filename, dryRun} = opts
     const idSelector = parseSelector(opts.idSelector)
     const contentSelector = (opts.contentSelector != null) ? parseSelector(opts.contentSelector) : null
     const contentFilters = parseFilters(opts.contentFilters)
     const idRegex = (opts.idRegex != null) ? compileIdRegex(opts.idRegex) : null
     const streamName = 'standard input'
 
-    const client = new RestClient({peerUrl})
+    const client = new RestClient({apiUrl})
 
     let inputStream: Readable
     if (filename) {

--- a/src/client/cli/commands/publishRaw.js
+++ b/src/client/cli/commands/publishRaw.js
@@ -8,9 +8,9 @@ module.exports = {
     'already been stored in the node.  `statementBodyId` should be the multihash ' +
     'identifier of the statement body.\n',
 
-  handler: (opts: {namespace: string, peerUrl: string, statementBodyId: string}) => {
-    const {namespace, peerUrl, statementBodyId} = opts
-    const client = new RestClient({peerUrl})
+  handler: (opts: {namespace: string, apiUrl: string, statementBodyId: string}) => {
+    const {namespace, apiUrl, statementBodyId} = opts
+    const client = new RestClient({apiUrl})
 
     client.publish(namespace, {object: statementBodyId})
       .then(

--- a/src/client/cli/commands/putData.js
+++ b/src/client/cli/commands/putData.js
@@ -14,10 +14,10 @@ module.exports = {
     batchSize: { default: BATCH_SIZE }
   },
 
-  handler: (opts: {peerUrl: string, batchSize: number, filename: ?string}) => {
-    const {peerUrl, batchSize, filename} = opts
+  handler: (opts: {apiUrl: string, batchSize: number, filename: ?string}) => {
+    const {apiUrl, batchSize, filename} = opts
     const streamName = filename || 'standard input'
-    const client = new RestClient({peerUrl})
+    const client = new RestClient({apiUrl})
 
     let items: Array<Object> = []
 

--- a/src/client/cli/commands/query.js
+++ b/src/client/cli/commands/query.js
@@ -3,13 +3,18 @@
 const RestClient = require('../../api/RestClient')
 
 module.exports = {
-  command: 'query [queryString]',
+  command: 'query <queryString>',
+  builder: {
+    remotePeer: {
+      description: 'the id of a remote peer to route the query to'
+    }
+  },
   description: 'send a mediachain query to the node for evaluation.\n',
-  handler: (opts: {peerUrl: string, queryString: string}) => {
-    const {peerUrl, queryString} = opts
+  handler: (opts: {peerUrl: string, queryString: string, remotePeer?: string}) => {
+    const {peerUrl, queryString, remotePeer} = opts
 
     const client = new RestClient({peerUrl})
-    client.queryStream(queryString)
+    client.queryStream(queryString, remotePeer)
       .then(response => {
         response.stream().on('data', printValue)
       })

--- a/src/client/cli/commands/query.js
+++ b/src/client/cli/commands/query.js
@@ -6,7 +6,8 @@ module.exports = {
   command: 'query <queryString>',
   builder: {
     remotePeer: {
-      description: 'the id of a remote peer to route the query to'
+      description: 'the id of a remote peer to route the query to',
+      alias: 'r'
     }
   },
   description: 'send a mediachain query to the node for evaluation.\n',

--- a/src/client/cli/commands/query.js
+++ b/src/client/cli/commands/query.js
@@ -11,10 +11,10 @@ module.exports = {
     }
   },
   description: 'send a mediachain query to the node for evaluation.\n',
-  handler: (opts: {peerUrl: string, queryString: string, remotePeer?: string}) => {
-    const {peerUrl, queryString, remotePeer} = opts
+  handler: (opts: {apiUrl: string, queryString: string, remotePeer?: string}) => {
+    const {apiUrl, queryString, remotePeer} = opts
 
-    const client = new RestClient({peerUrl})
+    const client = new RestClient({apiUrl})
     client.queryStream(queryString, remotePeer)
       .then(response => {
         response.stream().on('data', printValue)

--- a/src/client/cli/commands/statement.js
+++ b/src/client/cli/commands/statement.js
@@ -5,9 +5,9 @@ const RestClient = require('../../api/RestClient')
 module.exports = {
   command: 'statement <statementId>',
   description: 'retrieve a statement by its id\n',
-  handler: (opts: {statementId: string, peerUrl: string}) => {
-    const {statementId, peerUrl} = opts
-    const client = new RestClient({peerUrl})
+  handler: (opts: {statementId: string, apiUrl: string}) => {
+    const {statementId, apiUrl} = opts
+    const client = new RestClient({apiUrl})
 
     client.statement(statementId)
       .then(

--- a/src/client/cli/commands/status.js
+++ b/src/client/cli/commands/status.js
@@ -8,9 +8,9 @@ module.exports = {
   description: 'get or set the status of the node. ' +
     'if newStatus is not given, returns the current status. ' +
     'newStatus must be one of: online, offline, public\n',
-  handler: (opts: {peerUrl: string, newStatus?: string}) => {
-    const {peerUrl, newStatus} = opts
-    const client = new RestClient({peerUrl})
+  handler: (opts: {apiUrl: string, newStatus?: string}) => {
+    const {apiUrl, newStatus} = opts
+    const client = new RestClient({apiUrl})
 
     if (!newStatus) {
       return client.getStatus().then(console.log)

--- a/src/client/cli/index.js
+++ b/src/client/cli/index.js
@@ -5,11 +5,11 @@ require('yargs')
   .help()
   .example('$0 ping QmF00123', 'send a ping message to peer with id QmF00123')
   .demand(1, 'Missing command argument')
-  .option('peerUrl', {
-    alias: 'p',
+  .option('apiUrl', {
+    alias: ['p'],
     description: 'root URL of the REST API for a mediachain node',
     default: 'http://localhost:9002'
   })
-  .global('peerUrl')
+  .global('apiUrl')
   .commandDir('commands')
   .argv


### PR DESCRIPTION
Adds some features that were recently added to concat

- `listPeers` command to get list of peers from node's connected directory
- fetch ids and info from remote peers, format output instead of dumping JSON
- update mcclient query command to support remote query
- add merge command
- get / set peer's info message
- get / set NAT config
- rename cli flags a bit (`--peerUrl` is now `--apiUrl`)
