### PR TITLE
Add --info flag to listPeers command to fetch info strings

### DIFF
--- a/src/client/cli/commands/listPeers.js
+++ b/src/client/cli/commands/listPeers.js
@@ -4,13 +4,49 @@ const RestClient = require('../../api/RestClient')
 
 module.exports = {
   command: 'listPeers',
+  builder: {
+    info: {
+      type: 'boolean',
+      alias: 'i',
+      default: false,
+      description: 'Also fetch the "info" string for each peer.  This requires an extra network request per-peer.\n'
+    }
+  },
   description: `fetch a list of peers from the node's directory server.\n`,
-  handler: (opts: {apiUrl: string}) => {
-    const {apiUrl} = opts
+  handler: (opts: {apiUrl: string, info: boolean}) => {
+    const {apiUrl, info} = opts
     const client = new RestClient({apiUrl})
     client.listPeers().then(
-      peers => { peers.forEach(p => console.log(p)) },
+      peers => {
+        if (info) {
+          fetchInfos(client, peers)
+        } else {
+          peers.forEach(p => console.log(p))
+        }
+      },
       err => { console.error(err.message) }
     )
   }
+}
+
+function fetchInfos (client: RestClient, peerIds: Array<string>) {
+  let promises = []
+  for (const peer of peerIds) {
+    promises.push(
+      client.id(peer)
+        .then(ids => {
+          let msg = 'No info published'
+          if (ids.info != null && ids.info.length > 0) {
+            msg = ids.info
+          }
+          return peer + ` -- ${msg}`
+        })
+        .catch(err => `${peer} -- Unable to fetch info: ${err.message}`)
+    )
+  }
+
+  Promise.all(promises)
+    .then(messages => {
+      messages.forEach(m => console.log(m))
+    })
 }


### PR DESCRIPTION
```
mcclient listPeers --info
QmeiY2eHMwK92Zt6X4kUUC3MsjMmVb2VnGZ17DhnhRPCEQ -- Metadata for CC images from DPLA, 500px, and pexels; operated by Mediachain Labs.
QmZ6dckUhRouVr6AsBTpK6vMLVpcz1KAeJAJVQEZQ5gCek -- Metadata for CC images from flickr; operated by Mediachain Labs.
```

If an info lookup fails, it will print `Unable to fetch info: ${err.message}`, but won't fail the whole command.
