### PR TITLE
CLI option parsing tweaks

### DIFF
--- a/src/client/cli/commands/config.js
+++ b/src/client/cli/commands/config.js
@@ -9,6 +9,7 @@ module.exports = {
     return yargs
       .commandDir(path.join(__dirname, './config'))
       .help()
+      .strict()
   },
   handler: () => {}
 }

--- a/src/client/cli/commands/publishSchema.js
+++ b/src/client/cli/commands/publishSchema.js
@@ -7,10 +7,10 @@ const SCHEMA_NAMESPACE = 'mediachain.schemas'
 
 module.exports = {
   command: 'publishSchema <filename>',
-  description: 'publish a self-describing json-schema document to the "mediachain.schemas" namespace',
+  description: 'Publish a self-describing json-schema document to the local node.\n',
   builder: {
     namespace: {
-      description: 'namespace to publish the schema to',
+      description: 'Namespace to publish the schema to.',
       type: 'string',
       default: SCHEMA_NAMESPACE
     }

--- a/src/client/cli/index.js
+++ b/src/client/cli/index.js
@@ -1,9 +1,10 @@
 // @flow
 
-require('yargs')
+const yargs = require('yargs')
+
+yargs
   .usage('Usage: $0 [options] <command> [command-options]')
   .help()
-  .example('$0 ping QmF00123', 'send a ping message to peer with id QmF00123')
   .demand(1, 'Missing command argument')
   .option('apiUrl', {
     alias: ['p'],
@@ -13,4 +14,5 @@ require('yargs')
   .global('apiUrl')
   .commandDir('commands')
   .strict()
+  .wrap(yargs.terminalWidth())
   .argv

--- a/src/client/cli/index.js
+++ b/src/client/cli/index.js
@@ -12,4 +12,5 @@ require('yargs')
   })
   .global('apiUrl')
   .commandDir('commands')
+  .strict()
   .argv


### PR DESCRIPTION
Enables strict mode for yargs option parser, so we print usage text and error out on unknown arguments / commands.

Also wraps the help text at the actual terminal width, instead of 80 columns, and fixes up the help text for the publishSchema command for consistency with the rest.