### PR TITLE
Throw error if idFilter returns null

### DIFF
--- a/scripts/build-jq.js
+++ b/scripts/build-jq.js
@@ -11,9 +11,9 @@ const JQ_INFO = {
 const path = require('path')
 const outputPath = path.join(__dirname, '..', 'node_modules', '.bin', 'jq')
 
-const fs = require('fs');
+const fs = require('fs')
 try {
-  fs.accessSync(outputPath, fs.F_OK);
+  fs.accessSync(outputPath, fs.F_OK)
   // already exists
   process.exit(0)
 } catch (e) {}

--- a/src/client/cli/commands/publish.js
+++ b/src/client/cli/commands/publish.js
@@ -176,6 +176,8 @@ function publishStream (opts: {
         )
       }
 
+      wki = wki.toString()
+
       const refs = [wki]
       const tags = [] // TODO: support extracting tags
       const deps = []
@@ -258,7 +260,7 @@ function publishBatch (client: RestClient,
 }
 
 function composeJQFilters (contentFilter: string, idFilter: string): string {
-  return `${contentFilter} as $output | {wki: ($output | ${idFilter} | tostring), obj: $output}`
+  return `${contentFilter} as $output | {wki: ($output | ${idFilter}), obj: $output}`
 }
 
 function printBatchResults (bodyHashes: Array<string>, statementIds: Array<string>, statements: Array<Object>,


### PR DESCRIPTION
Closes #63 

Moves the `toString` call on the id into javascript instead of putting it in the jq filter, so that `null` doesn't get transformed into `"null"`.
