### PR TITLE
Use jq for pretty printing

### DIFF
--- a/src/client/cli/commands/getData.js
+++ b/src/client/cli/commands/getData.js
@@ -1,19 +1,39 @@
 // @flow
 
 const RestClient = require('../../api/RestClient')
-const { prettyPrint } = require('../util')
+const { printJSON } = require('../util')
 
 module.exports = {
   command: 'getData <objectId>',
   description: 'Request the object with `objectId` from the local node and print to the console.\n',
+  builder: {
+    color: {
+      type: 'boolean',
+      description: 'Explicitly enable (or disable, with --no-color) colorized output.\n',
+      default: null,
+      defaultDescription: 'Print in color if stdout is a tty, and monochrome if piped or pretty-printing is disabled.'
+    },
+    pretty: {
+      type: 'boolean',
+      description: 'Pretty print the output.\n',
+      default: true,
+      defaultDescription: 'True.  Use --no-pretty for compact output.'
+    }
+  },
 
-  handler: (opts: {apiUrl: string, objectId: string}) => {
-    const {apiUrl, objectId} = opts
+  handler: (opts: {apiUrl: string, objectId: string, color: ?boolean, pretty: boolean}) => {
+    const {apiUrl, objectId, color, pretty} = opts
     const client = new RestClient({apiUrl})
 
     client.getData(objectId)
       .then(
-        prettyPrint,
+        obj => {
+          if (obj instanceof Buffer) {
+            console.log(obj.toString('base64'))
+          } else {
+            printJSON(obj, {color, pretty})
+          }
+        },
         err => console.error(err.message)
       )
   }

--- a/src/client/cli/commands/query.js
+++ b/src/client/cli/commands/query.js
@@ -1,7 +1,7 @@
 // @flow
 
 const RestClient = require('../../api/RestClient')
-const { prettyPrint } = require('../util')
+const { printJSON } = require('../util')
 
 module.exports = {
   command: 'query <queryString>',
@@ -9,16 +9,30 @@ module.exports = {
     remotePeer: {
       description: 'The id of a remote peer to route the query to.',
       alias: 'r'
+    },
+    color: {
+      type: 'boolean',
+      description: 'Explicitly enable (or disable, with --no-color) colorized output.\n',
+      default: null,
+      defaultDescription: 'Print in color if stdout is a tty, and monochrome if piped or pretty-printing is disabled.'
+    },
+    pretty: {
+      type: 'boolean',
+      description: 'Pretty print the output.\n',
+      default: true,
+      defaultDescription: 'True.  Use --no-pretty for compact output.'
     }
   },
   description: 'Send a mediachain query to the local node or a remote peer for evaluation.\n',
-  handler: (opts: {apiUrl: string, queryString: string, remotePeer?: string}) => {
-    const {apiUrl, queryString, remotePeer} = opts
+  handler: (opts: {apiUrl: string, queryString: string, remotePeer?: string, pretty: boolean, color?: boolean}) => {
+    const {apiUrl, queryString, remotePeer, pretty, color} = opts
 
     const client = new RestClient({apiUrl})
     client.queryStream(queryString, remotePeer)
       .then(response => {
-        response.stream().on('data', prettyPrint)
+        response.stream().on('data', result => {
+          printJSON(result, {color, pretty})
+        })
       })
       .catch(err => console.error(err.message))
   }

--- a/src/client/cli/commands/statement.js
+++ b/src/client/cli/commands/statement.js
@@ -1,19 +1,34 @@
 // @flow
 
 const RestClient = require('../../api/RestClient')
-const { prettyPrint } = require('../util')
+const { printJSON } = require('../util')
 
 module.exports = {
   command: 'statement <statementId>',
   description: 'Retrieve a statement from the local node by its id.\n',
-  handler: (opts: {statementId: string, apiUrl: string}) => {
-    const {statementId, apiUrl} = opts
+  builder: {
+    color: {
+      type: 'boolean',
+      description: 'Explicitly enable (or disable, with --no-color) colorized output.\n',
+      default: null,
+      defaultDescription: 'Print in color if stdout is a tty, and monochrome if piped or pretty-printing is disabled.'
+    },
+    pretty: {
+      type: 'boolean',
+      description: 'Pretty print the output.\n',
+      default: true,
+      defaultDescription: 'True.  Use --no-pretty for compact output.'
+    }
+  },
+
+  handler: (opts: {statementId: string, apiUrl: string, color: ?boolean, pretty: boolean}) => {
+    const {statementId, apiUrl, color, pretty} = opts
     const client = new RestClient({apiUrl})
 
     client.statement(statementId)
       .then(
-        prettyPrint,
-        err => console.error(err.message)
+        obj => { printJSON(obj, {color, pretty}) },
+        err => { console.error(err.message) }
       )
   }
 }

--- a/src/client/cli/util.js
+++ b/src/client/cli/util.js
@@ -4,13 +4,21 @@ const Multihash = require('multihashes')
 const { JQ_PATH } = require('../../metadata/jqStream')
 const childProcess = require('child_process')
 
-function prettyPrint (obj: Object, options: {color: boolean | 'auto'} = {color: 'auto'}) {
+function printJSON (obj: Object,
+                    options: {color?: ?boolean, pretty?: boolean} = {}) {
+  const compactOutput = options.pretty === false
+
   let useColor = false
-  if (options.color === true || (options.color === 'auto' && process.stdout.isTTY)) {
+  // print in color if explicitly enabled, or if pretty-printing to a tty
+  if (options.color === true || (options.color == null && process.stdout.isTTY && !compactOutput)) {
     useColor = true
   }
 
   const jqOpts = [(useColor ? '-C' : '-M'), '-a', '.']
+  if (options.pretty === false) {
+    jqOpts.unshift('-c')
+  }
+
   const output = childProcess.execFileSync(JQ_PATH, jqOpts, {input: JSON.stringify(obj), encoding: 'utf-8'})
   console.log(output)
 }
@@ -31,7 +39,7 @@ function isB58Multihash (str: string): boolean {
 }
 
 module.exports = {
-  prettyPrint,
+  printJSON,
   pluralizeCount,
   isB58Multihash
 }

--- a/src/client/cli/util.js
+++ b/src/client/cli/util.js
@@ -14,6 +14,12 @@ function printJSON (obj: Object,
     useColor = true
   }
 
+  if (!useColor && compactOutput) {
+    // skip jq if we don't want color or pretty printing
+    console.log(JSON.stringify(obj))
+    return
+  }
+
   const jqOpts = [(useColor ? '-C' : '-M'), '-a', '.']
   if (options.pretty === false) {
     jqOpts.unshift('-c')

--- a/src/client/cli/util.js
+++ b/src/client/cli/util.js
@@ -1,11 +1,18 @@
 // @flow
 
 const Multihash = require('multihashes')
+const { JQ_PATH } = require('../../metadata/jqStream')
+const childProcess = require('child_process')
 
-function prettyPrint (obj: Object) {
-  // for now, use console.dir to dump the object.
-  // when we have a hard dependency on jq, we can just pipe through it instead :)
-  console.dir(obj, {colors: true, depth: 1000})
+function prettyPrint (obj: Object, options: {color: boolean | 'auto'} = {color: 'auto'}) {
+  let useColor = false
+  if (options.color === true || (options.color === 'auto' && process.stdout.isTTY)) {
+    useColor = true
+  }
+
+  const jqOpts = [(useColor ? '-C' : '-M'), '-a', '.']
+  const output = childProcess.execFileSync(JQ_PATH, jqOpts, {input: JSON.stringify(obj), encoding: 'utf-8'})
+  console.log(output)
 }
 
 function pluralizeCount (count: number, word: string): string {


### PR DESCRIPTION
Pipes json through jq for pretty printing instead of using `console.dir`, so we get valid json output with quotes and such.

Defaults to printing in color if stdout is a TTY, but you can override with `prettyPrint(obj, {color: false})`

Will add the flag for pretty printing per @vyzo's suggestion; do we want it to be enabled or disabled by default?  Pretty output by default seems nicer for end users... @denisnazarov, thoughts?

closes #64 