### PR TITLE
Deploy to npm on commits tagged with `v*`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ script:
   - npm run test &&./integration-test/run-in-docker.sh
 
 deploy:
+  skip_cleanup: true
   provider: npm
   email: yusef@napora.org
   api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,13 @@ before_install:
 script:
   - npm run test &&./integration-test/run-in-docker.sh
 
+deploy:
+  provider: npm
+  email: yusef@napora.org
+  api_key:
+    secure: M+mdGML/OzRCUzM39hxityHXNLSHBRUDJ0JuKnaooP8TRWa3buuiIbU3OtjUEizhWfR8VfAxFKzb+4ysdbqYuqWC67Hles85CKHnjl+JH+yj9FAJ+xb6lUyXy0Pd+ehwaAi79BgTRUtpTl11ECjqAT3Swqn0omRkC0R7rEZXFp+LCjnR2fPFceD09qaZMJpDuH72ciC4RFjIB1TWqZOWNh5C/SpmyEOKSpOsNXDYS3XhHjcEEp4kljFMwXt4hM7kN/oc3GL4b351+cEcnU0QJ1e/qyOFFgHz7j4aNzOP0lrGxsMa/gJQQE9ltr1Ql2AacUxxVfRckuRN8qqyFRtoqA/pZHmgvlKM6hDl/KhImLXYDEAyxgrbBGX4/LasezfUfF9Y4JfVQpKCO73n/R2WZrM2SBh9n4mUxbqJY0hqX69Oxsi9GLVwaWU+6aBwhXlijtq/MFb41rpwhcCmNtLyhN89twvQYcba6cDpAjH1zMKmmiT9H43smVnPDz0qsY6Lr1rwQmH5dtNCa8o/1ywYBlk9St5c9xzPSaxKgMTIGgdZUWqm9aFWzTGRgg9IxHcfwFIawDpr3amX6FpzGYaKeIrqEpm35MTs7I6SVOXRfqvOMxP/gr28hvGtqr4r48W/ZWnj8nkNdFGuSHVi6zwUTSzyJslYuUBRvzAqLixdSps=
+  on:
+    tags: true
+    repo: mediachain/aleph
+    # only publish if we're on a commit whose tag starts with 'v'
+    condition: $(git describe --tags) == v*

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,7 @@ deploy:
   skip_cleanup: true
   provider: npm
   email: yusef@napora.org
-  api_key:
-    secure: M+mdGML/OzRCUzM39hxityHXNLSHBRUDJ0JuKnaooP8TRWa3buuiIbU3OtjUEizhWfR8VfAxFKzb+4ysdbqYuqWC67Hles85CKHnjl+JH+yj9FAJ+xb6lUyXy0Pd+ehwaAi79BgTRUtpTl11ECjqAT3Swqn0omRkC0R7rEZXFp+LCjnR2fPFceD09qaZMJpDuH72ciC4RFjIB1TWqZOWNh5C/SpmyEOKSpOsNXDYS3XhHjcEEp4kljFMwXt4hM7kN/oc3GL4b351+cEcnU0QJ1e/qyOFFgHz7j4aNzOP0lrGxsMa/gJQQE9ltr1Ql2AacUxxVfRckuRN8qqyFRtoqA/pZHmgvlKM6hDl/KhImLXYDEAyxgrbBGX4/LasezfUfF9Y4JfVQpKCO73n/R2WZrM2SBh9n4mUxbqJY0hqX69Oxsi9GLVwaWU+6aBwhXlijtq/MFb41rpwhcCmNtLyhN89twvQYcba6cDpAjH1zMKmmiT9H43smVnPDz0qsY6Lr1rwQmH5dtNCa8o/1ywYBlk9St5c9xzPSaxKgMTIGgdZUWqm9aFWzTGRgg9IxHcfwFIawDpr3amX6FpzGYaKeIrqEpm35MTs7I6SVOXRfqvOMxP/gr28hvGtqr4r48W/ZWnj8nkNdFGuSHVi6zwUTSzyJslYuUBRvzAqLixdSps=
+  api_key: "$NPM_API_KEY"
   on:
     tags: true
     repo: mediachain/aleph

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # א
 
+[![npm version](https://badge.fury.io/js/aleph.svg)](https://badge.fury.io/js/aleph)
 [![Travis CI](https://travis-ci.org/mediachain/aleph.svg?branch=master)](https://travis-ci.org/mediachain/aleph.svg?branch=master)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/feross/standard)
 


### PR DESCRIPTION
Similar to the concat release process, this should let us just tag a release with a tag beginning with `v`, and it will publish to npm for us.

also adds an npm version badge to the readme, which I've been meaning to do for a while 😄 