### PR TITLE
Support `await` keyword to block on assignment in repl

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "prepublish": "npm run build"
   },
   "bin": {
+    "aleph": "./bin/aleph.js",
     "mcclient": "./bin/mcclient.js"
   },
   "repository": {

--- a/scripts/build-jq.js
+++ b/scripts/build-jq.js
@@ -11,9 +11,9 @@ const JQ_INFO = {
 const path = require('path')
 const outputPath = path.join(__dirname, '..', 'node_modules', '.bin', 'jq')
 
-const fs = require('fs');
+const fs = require('fs')
 try {
-  fs.accessSync(outputPath, fs.F_OK);
+  fs.accessSync(outputPath, fs.F_OK)
   // already exists
   process.exit(0)
 } catch (e) {}

--- a/src/peer/identity.js
+++ b/src/peer/identity.js
@@ -26,12 +26,11 @@ function loadIdentity (filePath: string): PeerId {
   return PeerId.createFromPrivKey(privKeyBytes)
 }
 
-
-function loadOrGenerateIdentity(filePath: string): PeerId {
+function loadOrGenerateIdentity (filePath: string): PeerId {
   let peerId
   try {
     loadIdentity(filePath)
-  } catch(err) {
+  } catch (err) {
     console.log(`Could not load from ${filePath}, generating new PeerId...`)
     peerId = generateIdentity()
     saveIdentity(peerId, filePath)
@@ -40,12 +39,12 @@ function loadOrGenerateIdentity(filePath: string): PeerId {
   return peerId
 }
 
-function inflateMultiaddr(multiaddrString: string): PeerInfo {
-    const multiaddr = Multiaddr(multiaddrString)
-    const peerInfo = new PeerInfo()
-    peerInfo.multiaddr.add(multiaddr)
+function inflateMultiaddr (multiaddrString: string): PeerInfo {
+  const multiaddr = Multiaddr(multiaddrString)
+  const peerInfo = new PeerInfo()
+  peerInfo.multiaddr.add(multiaddr)
 
-    return peerInfo
+  return peerInfo
 }
 
 module.exports = {

--- a/src/peer/repl/commands/repl.js
+++ b/src/peer/repl/commands/repl.js
@@ -1,6 +1,7 @@
 // @flow
 
 const os = require('os')
+const vm = require('vm')
 const Node = require('../../node')
 // $FlowIssue flow doesn't find repl builtin?
 const Repl = require('repl')
@@ -74,11 +75,6 @@ module.exports = {
   }
 }
 
-const EMPTY = '(' + os.EOL + ')'
-
-const ASSIGN_REGEX = /(.*\S+\s*[^=!><]=[^=>])(.*)/
-const REPL_ASSIGNMENT_KEY = '_AlephREPLResult'
-const vm = require('vm')
 
 /**
  * Helper to perform assignment in the repl. The idea is that, in the promiseEval wrapper,
@@ -90,7 +86,7 @@ const vm = require('vm')
  * @param assignmentFragment - the part of the command up to and including the `=`
  * @param result - the evaluated result of the right-hand side of the assignment statement
  */
-function performAssignment(context: Object, assignmentFragment: ?string, result: any) {
+function performAssignment (context: Object, assignmentFragment: ?string, result: any) {
   if (assignmentFragment != null) {
     const oldVal = context[REPL_ASSIGNMENT_KEY] // just in case the user defines a var with that key
     const assignCommand = assignmentFragment + REPL_ASSIGNMENT_KEY + ';'
@@ -100,10 +96,14 @@ function performAssignment(context: Object, assignmentFragment: ?string, result:
   }
 }
 
+const EMPTY = '(' + os.EOL + ')'
+const ASYNC_ASSIGN_REGEX = /(.*\S+\s*[^=!><]=[^=>]\s*)await(.*)/
+const REPL_ASSIGNMENT_KEY = '_AlephREPLResult'
+
 const promiseEval = (defaultEval) => (cmd, context, filename, callback) => {
   if (cmd === EMPTY) return callback()
 
-  const assignmentMatch = ASSIGN_REGEX.exec(cmd)
+  const assignmentMatch = ASYNC_ASSIGN_REGEX.exec(cmd)
   let assignmentFragment: ?string = null
   if (assignmentMatch !== null && assignmentMatch.length > 2) {
     assignmentFragment = assignmentMatch[1]

--- a/src/peer/repl/commands/repl.js
+++ b/src/peer/repl/commands/repl.js
@@ -31,32 +31,31 @@ module.exports = {
     const commands = {}
 
     let init, remotePeerInfo
-    if(remotePeer !== undefined){
+    if (remotePeer !== undefined) {
       remotePeerInfo = Identity.inflateMultiaddr(remotePeer)
 
-      commands.remoteQuery = function(queryString){
+      commands.remoteQuery = function (queryString) {
         return node.remoteQuery(remotePeerInfo, queryString)
       }
 
       init = node.start().then(() => {
         node.openConnection(remotePeerInfo)
       }).then(() => {
-        console.log("Connected to " + remotePeer)
+        console.log('Connected to ' + remotePeer)
       })
-
     } else {
-      console.log("No remote peer specified, running in detached mode")
+      console.log('No remote peer specified, running in detached mode')
       init = Promise.resolve(undefined)
     }
 
     // TODO: directory stuff
-    if(dir !== undefined){
+    if (dir !== undefined) {
       const dirInfo = Identity.inflateMultiaddr(dir)
       node.setDirectory(dirInfo)
-    } else if(false){
+    } else if (false) { // eslint-disable-line
       // TODO: get directory from remote peer (and amend message below)
     } else {
-      console.log("No directory specified, running without directory")
+      console.log('No directory specified, running without directory')
     }
 
     init.then(() => {
@@ -74,7 +73,6 @@ module.exports = {
     })
   }
 }
-
 
 /**
  * Helper to perform assignment in the repl. The idea is that, in the promiseEval wrapper,


### PR DESCRIPTION
This hacks in support for the `await` keyword, so you can do e.g. 

```
var result = await node.remoteQuery('SELECT * FROM foo.bar')
```

and it will block until the query completes and assign the result to the `result` var.  Tested on node 6.8.0 and 7.0.0 with the `--harmony-async-await` flag, which sadly doesn't work at the REPL.

It's implemented with a regex hack, that looks for assignment operations (an `=` that's not preceded by `=`, `!` `<` or `>` and not followed by `=` or `>`) that are followed by the `await` keyword.  Then it evaluates the right-hand side, chains a `.then` on if it's a `Promise`, and uses `vm.runInContext` to assign the value to the left-hand side of the original assignment statement.

Total hack, but it works.  Feel free to pull it in if you think it's worth the extra complexity.  Also, beyond the hack itself it's a little weird that the repl supports `await` but not `async`, and that neither are supported in the codebase.  I guess what I'm saying is my heart won't be broken if this ends up on the cutting room floor, but it could be nice 😄