### PR TITLE
Increase input size limit for cbor encoder

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "multihashing": "^0.2.1",
     "ndjson": "^1.4.3",
     "node-fetch": "^1.6.3",
+    "nofilter": "0.0.3",
     "object-path": "^0.11.2",
     "peer-book": "^0.3.0",
     "peer-id": "^0.7.0",

--- a/src/metadata/serialize.js
+++ b/src/metadata/serialize.js
@@ -1,10 +1,30 @@
 // @flow
 
-// For now, this is just a very thin wrapper around the cbor lib.
-// It exists so that we can swap out the implementation later without changing call sites
-
 const cbor = require('cbor')
-const {encode, decode} = cbor
+const NoFilter = require('nofilter')
+const {Encoder, decode} = cbor
+
+// the default encoder fails if given input > 16KB.  Up this to 1MB to support big objects
+const MAX_INPUT_SIZE = 1024 * 1024
+
+// The default cbor Encoder.encode function, with the the stream highWaterMark overridden
+function encode () {
+  const objs = Array.prototype.slice.apply(arguments)
+  const enc = new Encoder({highWaterMark: MAX_INPUT_SIZE})
+  const bs = new NoFilter()
+  enc.pipe(bs)
+  for (const o of objs) {
+    if (typeof o === 'undefined') {
+      enc._pushUndefined()
+    } else if (o === null) {
+      enc._pushObject(null)
+    } else {
+      enc.write(o)
+    }
+  }
+  enc.end()
+  return bs.read()
+}
 
 module.exports = {
   encode,


### PR DESCRIPTION
This prevents the cbor encoder from choking on objects larger than 16KB.  I set the new limit at 1MB, so hopefully that's enough for everybody 😄 