### PR TITLE
Update libp2p-swarm

### DIFF
--- a/integration-test/ping_test.js
+++ b/integration-test/ping_test.js
@@ -12,7 +12,7 @@ describe('Ping', () => {
   let nodeIds = []
 
   before(() => {
-    return loadTestNodeIds().then(res => nodeIds = res)
+    return loadTestNodeIds().then(res => { nodeIds = res })
   })
 
   it('pings a concat node directly by PeerInfo', () => {

--- a/integration-test/query_test.js
+++ b/integration-test/query_test.js
@@ -18,7 +18,7 @@ describe('Query', () => {
   let nodeIds = []
 
   before(() => {
-    const nodeIdsP = loadTestNodeIds().then(res => nodeIds = res)
+    const nodeIdsP = loadTestNodeIds().then(res => { nodeIds = res })
     const concatClientP = concatNodeClient().then(client => client.publish({namespace: 'foo.bar'}, ...seedStatements))
     return Promise.all([nodeIdsP, concatClientP])
   })

--- a/integration-test/remote_data_test.js
+++ b/integration-test/remote_data_test.js
@@ -14,10 +14,11 @@ const seedObjects = [
 ]
 
 describe('Remote Data Fetching', () => {
-  let nodeIds = [], dataIds = []
+  let nodeIds = []
+  let dataIds = []
 
   before(() => {
-    const nodeIdsP = loadTestNodeIds().then(res => nodeIds = res)
+    const nodeIdsP = loadTestNodeIds().then(res => { nodeIds = res })
     const concatClientP = concatNodeClient()
       .then(client => client.putData(...seedObjects))
       .then(ids => { dataIds = ids })

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1174,7 +1174,14 @@
     "libp2p-crypto": {
       "version": "0.7.1",
       "from": "libp2p-crypto@0.7.1",
-      "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.7.1.tgz"
+      "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.7.1.tgz",
+      "dependencies": {
+        "webcrypto-shim": {
+          "version": "0.1.1",
+          "from": "dignifiedquire/webcrypto-shim#master",
+          "resolved": "git://github.com/dignifiedquire/webcrypto-shim.git#90cbb1b09161c5a8b21cee3b08c78afef1f6cf54"
+        }
+      }
     },
     "libp2p-identify": {
       "version": "0.3.0",
@@ -1189,12 +1196,19 @@
     "libp2p-spdy": {
       "version": "0.10.0",
       "from": "libp2p-spdy@0.10.0",
-      "resolved": "https://registry.npmjs.org/libp2p-spdy/-/libp2p-spdy-0.10.0.tgz"
+      "resolved": "https://registry.npmjs.org/libp2p-spdy/-/libp2p-spdy-0.10.0.tgz",
+      "dependencies": {
+        "browserify-zlib": {
+          "version": "0.1.5",
+          "from": "ipfs/browserify-zlib",
+          "resolved": "git://github.com/ipfs/browserify-zlib.git#9993effe9f670367bf96b9d23c3e5ca0e1ed4036"
+        }
+      }
     },
     "libp2p-swarm": {
-      "version": "0.25.0",
-      "from": "libp2p-swarm@>=0.25.0 <0.26.0",
-      "resolved": "https://registry.npmjs.org/libp2p-swarm/-/libp2p-swarm-0.25.0.tgz"
+      "version": "0.26.2",
+      "from": "libp2p-swarm@0.26.2",
+      "resolved": "https://registry.npmjs.org/libp2p-swarm/-/libp2p-swarm-0.26.2.tgz"
     },
     "libp2p-tcp": {
       "version": "0.9.1",
@@ -1625,9 +1639,9 @@
       }
     },
     "multistream-select": {
-      "version": "0.12.0",
-      "from": "multistream-select@>=0.12.0 <0.13.0",
-      "resolved": "https://registry.npmjs.org/multistream-select/-/multistream-select-0.12.0.tgz",
+      "version": "0.13.0",
+      "from": "multistream-select@>=0.13.0 <0.14.0",
+      "resolved": "https://registry.npmjs.org/multistream-select/-/multistream-select-0.13.0.tgz",
       "dependencies": {
         "varint": {
           "version": "4.0.1",
@@ -2543,11 +2557,6 @@
       "version": "0.1.0",
       "from": "webcrypto@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/webcrypto/-/webcrypto-0.1.0.tgz"
-    },
-    "webcrypto-shim": {
-      "version": "0.1.1",
-      "from": "dignifiedquire/webcrypto-shim#master",
-      "resolved": "git://github.com/dignifiedquire/webcrypto-shim.git#90cbb1b09161c5a8b21cee3b08c78afef1f6cf54"
     },
     "which-module": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "multihashing": "^0.2.1",
     "ndjson": "^1.4.3",
     "node-fetch": "^1.6.3",
+    "node-webcrypto-ossl": "^1.0.7",
     "nofilter": "0.0.3",
     "object-path": "^0.11.2",
     "peer-book": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "multihashing": "^0.2.1",
     "ndjson": "^1.4.3",
     "node-fetch": "^1.6.3",
-    "node-webcrypto-ossl": "^1.0.7",
     "nofilter": "0.0.3",
     "object-path": "^0.11.2",
     "peer-book": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "libp2p-crypto": "0.7.1",
     "libp2p-secio": "0.6.3",
     "libp2p-spdy": "0.10.0",
-    "libp2p-swarm": "^0.25.0",
+    "libp2p-swarm": "0.26.2",
     "libp2p-tcp": "^0.9.1",
     "libp2p-websockets": "0.9.1",
     "mafmt": "^2.1.2",

--- a/src/peer/directory.js
+++ b/src/peer/directory.js
@@ -48,7 +48,7 @@ class DirectoryNode {
     return this.p2p.peerInfo
   }
 
-  registerHandler (conn: Connection) {
+  registerHandler (protocol: string, conn: Connection) {
     // for some reason, conn.peerInfo is always null here,
     // so we store the peerInfo from the register message
     let peerForConn: ?PeerInfo = null
@@ -84,7 +84,7 @@ class DirectoryNode {
     )
   }
 
-  lookupHandler (conn: Connection) {
+  lookupHandler (protocol: string, conn: Connection) {
     const abortable = this.p2p.newAbortable()
 
     pull(
@@ -114,7 +114,7 @@ class DirectoryNode {
     }
   }
 
-  listHandler (conn: Connection) {
+  listHandler (protocol: string, conn: Connection) {
 
   }
 }

--- a/src/peer/identity.js
+++ b/src/peer/identity.js
@@ -1,8 +1,6 @@
 const thenifyAll = require('thenify-all')
-const fs = thenifyAll(require('fs'), {}
-  ['readFile'])
-const PeerId = thenifyAll(require('peer-id'), {}
-  ['createFromPrivKey'])
+const fs = thenifyAll(require('fs'), {}, ['readFile'])
+const PeerId = thenifyAll(require('peer-id'), {}, ['createFromPrivKey'])
 const crypto = require('libp2p-crypto')
 
 const KEY_TYPE = 'RSA'  // change to ECC when possible

--- a/src/peer/node.js
+++ b/src/peer/node.js
@@ -140,7 +140,7 @@ class MediachainNode {
       ))
   }
 
-  pingHandler (conn: Connection) {
+  pingHandler (protocol: string, conn: Connection) {
     pull(
       conn,
       protoStreamDecode(pb.node.Ping),

--- a/test/ping_test.js
+++ b/test/ping_test.js
@@ -2,17 +2,14 @@
 
 const assert = require('assert')
 const { before, describe, it } = require('mocha')
-
 const { loadTestNodeIds, makeNode } = require('./util')
 
 describe('Ping', () => {
   let p1, p2
-  before(() => {
-    return loadTestNodeIds().then(nodeIds => {
-	  p1 = makeNode({peerId: nodeIds.pop()})
-	  p2 = makeNode({peerId: nodeIds.pop()})
-    })
-  })
+  before(() => loadTestNodeIds().then(nodeIds => {
+    p1 = makeNode({peerId: nodeIds.pop()})
+    p2 = makeNode({peerId: nodeIds.pop()})
+  }))
 
   it('pings another node directly by PeerInfo', () => {
     return Promise.all([p1.start(), p2.start()])  // start both peers

--- a/test/remote_query_test.js
+++ b/test/remote_query_test.js
@@ -12,7 +12,6 @@ const {
 } = require('../src/peer/util')
 const { loadTestNodeIds, makeNode } = require('./util')
 
-
 import type Node from '../src/peer/node'
 import type { QueryResultMsg } from '../src/protobuf/types'
 import type { Connection } from 'interface-connection'

--- a/test/remote_query_test.js
+++ b/test/remote_query_test.js
@@ -18,7 +18,7 @@ import type { QueryResultMsg } from '../src/protobuf/types'
 import type { Connection } from 'interface-connection'
 
 // accept any query and return a stream of the given results
-const queryHandler = (results: Array<QueryResultMsg>) => (conn: Connection) => pull(
+const queryHandler = (results: Array<QueryResultMsg>) => (protocol: string, conn: Connection) => pull(
   conn,
   protoStreamDecode(pb.node.QueryRequest),
   pull.map(() => results),


### PR DESCRIPTION
Bumps libp2p-swarm to 0.26.2 and updates our protocol handlers to accept the protocol string as their first arg, since the API changed.
