### PR TITLE
Timeouts for mcclient requests, better behavior for `listPeers -i`

### DIFF
--- a/src/client/api/RestClient.js
+++ b/src/client/api/RestClient.js
@@ -58,9 +58,9 @@ class RestClient {
 
   constructor (options: {apiUrl?: string, requestTimeout?: number}) {
     this.apiUrl = options.apiUrl || ''
-    this.requestTimeout = (options.requestTimeout != null) ?
-      options.requestTimeout :
-      DEFAULT_REQUEST_TIMEOUT
+    this.requestTimeout = (options.requestTimeout != null)
+      ? options.requestTimeout
+      : DEFAULT_REQUEST_TIMEOUT
   }
 
   _makeUrl (path: string): string {

--- a/src/client/api/RestClient.js
+++ b/src/client/api/RestClient.js
@@ -8,7 +8,7 @@ import type { Transform as TransformStream, Duplex as DuplexStream } from 'strea
 import type { StatementMsg, SimpleStatementMsg } from '../../protobuf/types'
 export type NodeStatus = 'online' | 'offline' | 'public'
 
-const DEFAULT_REQUEST_TIMEOUT = 10000
+const DEFAULT_REQUEST_TIMEOUT = 15000
 
 type FetchResponse = {
   text: () => Promise<string>,

--- a/src/client/cli/commands/listPeers.js
+++ b/src/client/cli/commands/listPeers.js
@@ -31,23 +31,16 @@ module.exports = {
 }
 
 function fetchInfos (client: RestClient, peerIds: Array<string>) {
-  let promises = []
   for (const peer of peerIds) {
-    promises.push(
-      client.id(peer)
-        .then(ids => {
-          let msg = 'No info published'
-          if (ids.info != null && ids.info.length > 0) {
-            msg = ids.info
-          }
-          return peer + ` -- ${msg}`
-        })
-        .catch(err => `${peer} -- Unable to fetch info: ${err.message}`)
-    )
+    client.id(peer)
+      .then(ids => {
+        let msg = 'No info published'
+        if (ids.info != null && ids.info.length > 0) {
+          msg = ids.info
+        }
+        return peer + ` -- ${msg}`
+      })
+      .catch(err => `${peer} -- Unable to fetch info: ${err.message}`)
+      .then(console.log)
   }
-
-  Promise.all(promises)
-    .then(messages => {
-      messages.forEach(m => console.log(m))
-    })
 }


### PR DESCRIPTION
This adds a default 15s timeout to all `RestClient` requests.  You can override the default by providing a `requestTimeout` to the constructor options when creating the `RestClient`.  Long-running requests (big queries, etc) aren't affected by the timeout, just cases where no data is received within the limit.

Also changes the behavior of the `listPeers -i` command to print the peer id and info string as soon as the info request completes, rather than waiting for all requests to complete.  This means that reachable nodes are immediately shown, and there's a delay for unreachable nodes before an error is printed.