### PR TITLE
Dial timeouts for p2p connections

### DIFF
--- a/src/peer/util.js
+++ b/src/peer/util.js
@@ -163,6 +163,20 @@ const resultStreamThrough: MediachainStreamThrough<*> = (read) => {
   }
 }
 
+/**
+ * Reject `promise` if it doesn't complete within `timeout` milliseconds
+ * @param timeout milliseconds to wait before rejecting
+ * @param promise a promise that you want to set a timeout for
+ * @returns a Promise that will resolve to the value of `promise`, unless the timeout is exceeded
+ */
+function promiseTimeout<T> (timeout: number, promise: Promise<T>): Promise<T> {
+  return Promise.race([promise, new Promise((resolve, reject) => {
+    setTimeout(() => {
+      reject(new Error(`Timeout of ${timeout}ms exceeded`))
+    }, timeout)
+  })])
+}
+
 module.exports = {
   protoStreamEncode,
   protoStreamDecode,
@@ -171,5 +185,6 @@ module.exports = {
   peerInfoProtoMarshal,
   pullToPromise,
   pullRepeatedly,
-  resultStreamThrough
+  resultStreamThrough,
+  promiseTimeout
 }

--- a/src/peer/util.js
+++ b/src/peer/util.js
@@ -89,11 +89,16 @@ function peerInfoProtoMarshal (peerInfo: PeerInfo): PeerInfoMsg {
  * @returns {Promise} a promise that will resolve to the first value that reaches the end of the pipeline.
  */
 function pullToPromise<T> (...streams: Array<Function>): Promise<T> {
-  return new Promise(resolve => {
+  return new Promise((resolve, reject) => {
     pull(
       ...streams,
       pull.take(1),
-      pull.drain(resolve)
+      pull.collect((err, values) => {
+        if (err) {
+          return reject(err)
+        }
+        resolve(values.pop())
+      })
     )
   })
 }

--- a/test/ping_test.js
+++ b/test/ping_test.js
@@ -3,17 +3,30 @@
 const assert = require('assert')
 const { before, describe, it } = require('mocha')
 const { loadTestNodeIds, makeNode } = require('./util')
+const PeerInfo = require('peer-info')
+const Multiaddr = require('multiaddr')
 
-describe('Ping', () => {
-  let p1, p2
+describe('Ping', function () {
+  let p1, p2, invalidPeer
   before(() => loadTestNodeIds().then(nodeIds => {
     p1 = makeNode({peerId: nodeIds.pop()})
     p2 = makeNode({peerId: nodeIds.pop()})
+    invalidPeer = PeerInfo(nodeIds.pop())
+    invalidPeer.multiaddr.add(Multiaddr('/ip4/1.2.3.4/tcp/4321'))
   }))
 
   it('pings another node directly by PeerInfo', () => {
     return Promise.all([p1.start(), p2.start()])  // start both peers
       .then(() => p1.ping(p2.peerInfo))
       .then(result => assert(result))
+  })
+
+  it('fails to ping a non-existent node', () => {
+    p1.p2p.dialTimeout = 20
+    return p1.start()
+      .then(() => p1.ping(invalidPeer))
+      .catch(err => {
+        assert(err != null)
+      })
   })
 })


### PR DESCRIPTION
This adds a 10s timeout when dialing using libp2p, and also fixes the `pullToPromise` helper, which was ignoring errors instead of rejecting the promise.

This should fix the broken behavior in the aleph repl where it would eventually return `true` when pinging an unreachable node.

You can change the timeout length on a mediachain node after construction by doing `node.p2p.dialTimeout = newValue`.  It might be worth adding the timeout duration as an argument to the MediachainNode class constructor though; right now it's just in the P2PNode class.