### PR TITLE
Use async PeerId API

### DIFF
--- a/src/peer/identity.js
+++ b/src/peer/identity.js
@@ -36,35 +36,35 @@ function dirExists (filePath: string): boolean {
   }
 }
 
-function loadOrGenerateIdentity(filePath: string): Promise<PeerId> {
-    return loadIdentity(filePath)
-      .catch(err => {
-        if (err.code === 'ENOENT') {
-          if (!dirExists(path.dirname(filePath))) {
-            const e = new Error(
-              `Unable to access file at ${filePath} because the containing directory ` +
-              `does not exist.`)
-            e.cause = err
-            throw e
-          }
-        }
-        if (err.code === 'EACCES') {
+function loadOrGenerateIdentity (filePath: string): Promise<PeerId> {
+  return loadIdentity(filePath)
+    .catch(err => {
+      if (err.code === 'ENOENT') {
+        if (!dirExists(path.dirname(filePath))) {
           const e = new Error(
-            `Unable to access file at ${filePath} - permission denied.`
-          )
+            `Unable to access file at ${filePath} because the containing directory ` +
+            `does not exist.`)
           e.cause = err
           throw e
         }
-        console.log(`Could not load from ${filePath}, generating new PeerId...`)
-        return generateIdentity()
-      })
-      .then(id => {
-        saveIdentity(id, filePath)
-        return id
-      })
+      }
+      if (err.code === 'EACCES') {
+        const e = new Error(
+          `Unable to access file at ${filePath} - permission denied.`
+        )
+        e.cause = err
+        throw e
+      }
+      console.log(`Could not load from ${filePath}, generating new PeerId...`)
+      return generateIdentity()
+    })
+    .then(id => {
+      saveIdentity(id, filePath)
+      return id
+    })
 }
 
-function inflateMultiaddr(multiaddrString: string): PeerInfo {
+function inflateMultiaddr (multiaddrString: string): PeerInfo {
   const multiaddr = Multiaddr(multiaddrString)
   const ipfsIdB58String = multiaddr.stringTuples().filter((tuple) => {
     if (tuple[0] === IPFS_CODE) {

--- a/src/peer/libp2p_node.js
+++ b/src/peer/libp2p_node.js
@@ -19,7 +19,7 @@ const OFFLINE_ERROR_MESSAGE = 'The libp2p node is not started yet'
 const IPFS_CODE = 421
 
 type P2PNodeOptions = {
-  peerInfo?: PeerInfo,
+  peerInfo: PeerInfo,
   peerBook?: PeerBook,
   disableSecureIO?: boolean
 }
@@ -34,11 +34,6 @@ class P2PNode {
   constructor (options: P2PNodeOptions) {
     let {peerInfo, peerBook, disableSecureIO} = options
     this.isOnline = false
-
-    if (!peerInfo) {
-      peerInfo = new PeerInfo()
-      peerInfo.multiaddr.add(multiaddr('/ip4/0.0.0.0/tcp/0'))
-    }
 
     if (!peerBook) peerBook = new PeerBook()
 

--- a/src/peer/node.js
+++ b/src/peer/node.js
@@ -200,11 +200,11 @@ class MediachainNode {
 
   // local queries (NOT IMPLEMENTED -- NO LOCAL STORE)
   query (queryString: string): Promise<Array<QueryResultMsg>> {
-    throw new Error("Local statement db not implemented!")
+    throw new Error('Local statement db not implemented!')
   }
 
   data (keys: Array<string>): Array<DataResultMsg> {
-    throw new Error("Local datastore not implemented!")
+    throw new Error('Local datastore not implemented!')
   }
 }
 

--- a/src/peer/node.js
+++ b/src/peer/node.js
@@ -218,15 +218,15 @@ class RemoteNode {
   }
 
   ping (): Promise<boolean> {
-    return node.ping(this.remotePeerInfo)
+    return this.node.ping(this.remotePeerInfo)
   }
 
   query (queryString: string): Promise<Array<QueryResultMsg>> {
-    return node.query(this.remotePeerInfo, queryString)
+    return this.node.remoteQuery(this.remotePeerInfo, queryString)
   }
 
   data (keys: Array<string>): Array<DataResultMsg> {
-    return node.remoteData(this.remotePeerInfo, keys)
+    return this.node.remoteData(this.remotePeerInfo, keys)
   }
 }
 

--- a/src/peer/repl/commands/repl.js
+++ b/src/peer/repl/commands/repl.js
@@ -23,6 +23,10 @@ module.exports = {
     const {dir, remotePeer} = opts
 
     bootstrap(opts)
+      .catch(err => {
+        console.error(`Error setting up aleph node: ${err.message}`)
+        process.exit(1)
+      })
       .then(node => {
 
         let init, remote, remotePeerInfo

--- a/src/peer/repl/commands/repl.js
+++ b/src/peer/repl/commands/repl.js
@@ -1,7 +1,7 @@
 // @flow
 
 const os = require('os')
-const { MediachainNode: Node, RemoteNode } = require('../../node');
+const { MediachainNode: Node, RemoteNode } = require('../../node')
 // $FlowIssue flow doesn't find repl builtin?
 const Repl = require('repl')
 const Identity = require('../../identity')
@@ -28,7 +28,6 @@ module.exports = {
         process.exit(1)
       })
       .then(node => {
-
         let init, remote, remotePeerInfo
         if (remotePeer !== undefined) {
           remotePeerInfo = Identity.inflateMultiaddr(remotePeer)
@@ -36,9 +35,9 @@ module.exports = {
 
           init = node.start()
             .then(() => { node.openConnection(remotePeerInfo) })
-            .then(() => { console.log("Connected to " + remotePeer) })
+            .then(() => { console.log(`Connected to ${remotePeer}`) })
         } else {
-          console.log("No remote peer specified, running in detached mode")
+          console.log('No remote peer specified, running in detached mode')
           // TODO: create dummy RemoteNode class that just throws
           init = Promise.resolve()
         }
@@ -47,10 +46,10 @@ module.exports = {
         if (dir !== undefined) {
           const dirInfo = Identity.inflateMultiaddr(dir)
           node.setDirectory(dirInfo)
-        } else if (false) {
+        } else if (false) { // eslint-disable-line
           // TODO: get directory from remote peer (and amend message below)
         } else {
-          console.log("No directory specified, running without directory")
+          console.log('No directory specified, running without directory')
         }
 
         init.then(() => {

--- a/src/peer/repl/commands/repl.js
+++ b/src/peer/repl/commands/repl.js
@@ -25,17 +25,14 @@ module.exports = {
     bootstrap(opts)
       .then(node => {
 
-        let init, remote
+        let init, remote, remotePeerInfo
         if (remotePeer !== undefined) {
-          init = node.start()
-            .then(() => Identity.inflateMultiaddr(remotePeer))
-            .then(remotePeerInfo => {
-              node.openConnection(remotePeerInfo)
-              remote = new RemoteNode(node, remotePeerInfo)
-            }).then(() => {
-            console.log("Connected to " + remotePeer)
-          })
+          remotePeerInfo = Identity.inflateMultiaddr(remotePeer)
+          remote = new RemoteNode(node, remotePeerInfo)
 
+          init = node.start()
+            .then(() => { node.openConnection(remotePeerInfo) })
+            .then(() => { console.log("Connected to " + remotePeer) })
         } else {
           console.log("No remote peer specified, running in detached mode")
           // TODO: create dummy RemoteNode class that just throws
@@ -44,10 +41,8 @@ module.exports = {
 
         // TODO: directory stuff
         if (dir !== undefined) {
-          Identity.inflateMultiaddr(dir)
-            .then(dirInfo => {
-              node.setDirectory(dirInfo)
-            })
+          const dirInfo = Identity.inflateMultiaddr(dir)
+          node.setDirectory(dirInfo)
         } else if (false) {
           // TODO: get directory from remote peer (and amend message below)
         } else {


### PR DESCRIPTION
Also makes `peerInfo` mandatory in the MediachainNode constructor options, and reworks a few things in the repl command to please our new async overlords.