### PR TITLE
Support /mediachain/node/id protocol

### DIFF
--- a/integration-test/node_info_test.js
+++ b/integration-test/node_info_test.js
@@ -1,0 +1,34 @@
+// @flow
+/* eslint-env mocha */
+
+const assert = require('assert')
+const { before, describe, it } = require('mocha')
+
+const { loadTestNodeIds } = require('../test/util')
+const AlephNode = require('../src/peer/node')
+const { setConcatNodeStatus, concatNodePeerInfo, setConcatNodeInfoMessage } = require('./util')
+
+describe('Node Info', () => {
+  let nodeIds = []
+  const infoMessage = `I'm a concat test node`
+
+  before(() => {
+    return Promise.all([
+      loadTestNodeIds().then(res => { nodeIds = res }),
+      setConcatNodeInfoMessage(infoMessage)
+    ])
+  })
+
+  it('retrieves the node ids and info message from a concat node', () => {
+    const alephPeer = new AlephNode({peerId: nodeIds.pop()})
+    return alephPeer.start()
+      .then(() => setConcatNodeStatus('online'))
+      .then(() => concatNodePeerInfo())
+      .then(concatNodeInfo => alephPeer.remoteNodeInfo(concatNodeInfo))
+      .then(result => {
+        assert.equal(result.info, infoMessage,
+          'node info response should include correct info message'
+        )
+      })
+  })
+})

--- a/integration-test/util.js
+++ b/integration-test/util.js
@@ -76,6 +76,11 @@ function setConcatNodeStatus (status: NodeStatus): Promise<NodeStatus> {
     .then(client => client.setStatus(status))
 }
 
+function setConcatNodeInfoMessage (message: string): Promise<string> {
+  return concatNodeClient()
+    .then(client => client.setInfo(message))
+}
+
 function concatNodePeerInfo (): Promise<PeerInfo> {
   return Promise.all([concatNodeMultiaddr(), concatNodePeerId()])
     .then(([maddr, peerId]) => {
@@ -94,6 +99,7 @@ module.exports = {
   concatNodeMultiaddr,
   concatNodeClient,
   setConcatNodeStatus,
+  setConcatNodeInfoMessage,
   concatNodePeerId,
   concatNodePeerInfo
 }

--- a/src/peer/constants.js
+++ b/src/peer/constants.js
@@ -5,6 +5,7 @@ const Multiaddr = require('multiaddr')
 const DEFAULT_LISTEN_ADDR = Multiaddr('/ip4/127.0.0.1/tcp/0')
 const PROTOCOLS = {
   node: {
+    id: '/mediachain/node/id',
     ping: '/mediachain/node/ping',
     query: '/mediachain/node/query',
     data: '/mediachain/node/data'

--- a/src/peer/node.js
+++ b/src/peer/node.js
@@ -27,6 +27,8 @@ export type MediachainNodeOptions = {
   infoMessage?: string
 }
 
+const DEFAULT_INFO_MESSAGE = '(aleph)'
+
 class MediachainNode {
   p2p: P2PNode
   directory: ?PeerInfo
@@ -41,7 +43,7 @@ class MediachainNode {
       peerInfo.multiaddr.add(Multiaddr(addr))
     })
 
-    this.infoMessage = options.infoMessage || ''
+    this.infoMessage = options.infoMessage || DEFAULT_INFO_MESSAGE
 
     this.p2p = new P2PNode({peerInfo})
     this.directory = dirInfo

--- a/src/peer/node.js
+++ b/src/peer/node.js
@@ -16,19 +16,21 @@ const {
   resultStreamThrough
 } = require('./util')
 
-import type { QueryResultMsg, DataResultMsg } from '../protobuf/types'
+import type { QueryResultMsg, DataResultMsg, NodeInfoMsg } from '../protobuf/types'
 import type { Connection } from 'interface-connection'
 import type { PullStreamSource } from './util'
 
 export type MediachainNodeOptions = {
   peerId: PeerId,
   dirInfo?: PeerInfo,
-  listenAddresses?: Array<Multiaddr | string>
+  listenAddresses?: Array<Multiaddr | string>,
+  infoMessage?: string
 }
 
 class MediachainNode {
   p2p: P2PNode
   directory: ?PeerInfo
+  infoMessage: string
 
   constructor (options: MediachainNodeOptions) {
     let {peerId, dirInfo, listenAddresses} = options
@@ -39,9 +41,12 @@ class MediachainNode {
       peerInfo.multiaddr.add(Multiaddr(addr))
     })
 
+    this.infoMessage = options.infoMessage || ''
+
     this.p2p = new P2PNode({peerInfo})
     this.directory = dirInfo
     this.p2p.handle(PROTOCOLS.node.ping, this.pingHandler.bind(this))
+    this.p2p.handle(PROTOCOLS.node.id, this.idHandler.bind(this))
   }
 
   start (): Promise<void> {
@@ -58,6 +63,10 @@ class MediachainNode {
 
   setDirectory (dirInfo: PeerInfo) {
     this.directory = dirInfo
+  }
+
+  setInfoMessage (message: string) {
+    this.infoMessage = message
   }
 
   register (): Promise<boolean> {
@@ -147,6 +156,31 @@ class MediachainNode {
       protoStreamEncode(pb.node.Pong),
       conn
     )
+  }
+
+  idHandler (protocol: string, conn: Connection) {
+    const response = {
+      peer: this.peerInfo.id.toB58String(),
+      info: this.infoMessage
+    }
+
+    pull(
+      conn,
+      protoStreamDecode(pb.node.NodeInfoRequest),
+      pull.map(() => response),
+      protoStreamEncode(pb.node.NodeInfo),
+      conn
+    )
+  }
+
+  remoteNodeInfo (peer: PeerInfo | PeerId | string): Promise<NodeInfoMsg> {
+    return this.openConnection(peer, PROTOCOLS.node.id)
+      .then(conn => pullToPromise(
+        pull.once({}),
+        protoStreamEncode(pb.node.NodeInfoRequest),
+        conn,
+        protoStreamDecode(pb.node.NodeInfo)
+      ))
   }
 
   remoteQueryStream (peer: PeerInfo | PeerId | string, queryString: string): Promise<PullStreamSource> {

--- a/src/protobuf/index.js
+++ b/src/protobuf/index.js
@@ -14,6 +14,8 @@ import type {
   ListPeersResponseMsg,
   PingMsg,
   PongMsg,
+  NodeInfoRequestMsg,
+  NodeInfoMsg,
   QueryRequestMsg,
   QueryResultMsg,
   QueryResultValueMsg,
@@ -45,6 +47,8 @@ type AllProtos = {
   node: {
     Ping: ProtoCodec<PingMsg>,
     Pong: ProtoCodec<PongMsg>,
+    NodeInfoRequest: ProtoCodec<NodeInfoRequestMsg>,
+    NodeInfo: ProtoCodec<NodeInfoMsg>,
     QueryRequest: ProtoCodec<QueryRequestMsg>,
     QueryResult: ProtoCodec<QueryResultMsg>,
     QueryResultValue: ProtoCodec<QueryResultValueMsg>,
@@ -98,6 +102,8 @@ function loadProtos (): AllProtos {
     node: {
       Ping: pb.Ping,
       Pong: pb.Pong,
+      NodeInfoRequest: pb.NodeInfoRequest,
+      NodeInfo: pb.NodeInfo,
       QueryRequest: pb.QueryRequest,
       QueryResult: pb.QueryResult,
       QueryResultValue: pb.QueryResultValue,

--- a/test/node_info_test.js
+++ b/test/node_info_test.js
@@ -1,0 +1,26 @@
+/* eslint-env mocha */
+
+const assert = require('assert')
+const { before, describe, it } = require('mocha')
+const { loadTestNodeIds, makeNode } = require('./util')
+
+describe('Node Info', function () {
+  const infoMessage = 'tests are great!'
+
+  let p1, p2
+  before(() => loadTestNodeIds().then(nodeIds => {
+    p1 = makeNode({peerId: nodeIds.pop()})
+    p2 = makeNode({peerId: nodeIds.pop(), infoMessage})
+  }))
+
+  it('retrieves the ids and info message from another node', () => {
+    return Promise.all([p1.start(), p2.start()])  // start both peers
+      .then(() => p1.remoteNodeInfo(p2.peerInfo))
+      .then(result => {
+        assert.equal(result.peer, p2.peerInfo.id.toB58String(),
+          'node info response should include correct peer id')
+        assert.equal(result.info, infoMessage,
+          'node info response should include correct info message')
+      })
+  })
+})


### PR DESCRIPTION
Adds a `remoteNodeInfo` method to `MediachainNode` that retrieves the ids and info message.  Also adds an `idHandler` to provide the same, although the publisher id is blank since aleph doesn't support them yet.  I did add an `infoMessage` to the node constructor, so you can set the info string.

A thought I had when adding that `infoMessage` parameter is that it won't persist between invocations... maybe it's worth adding a way to save the node configuration (id, info, directory address, etc) to a single JSON file?