### PR TITLE
Add structural jsonld validation to `mcclient validate`

### DIFF
--- a/src/client/cli/commands/validate.js
+++ b/src/client/cli/commands/validate.js
@@ -1,6 +1,7 @@
 // @flow
 
 const fs = require('fs')
+const path = require('path')
 const RestClient = require('../../api/RestClient')
 const { JQTransform } = require('../../../metadata/jqStream')
 const { validate, loadSelfDescribingSchema, validateSelfDescribingSchema } = require('../../../metadata/schema')
@@ -10,17 +11,29 @@ import type { SelfDescribingSchema } from '../../../metadata/schema'
 
 type HandlerOptions = {
   apiUrl: string,
-  schema: string,
+  schema?: string,
+  jsonld: boolean,
   filename?: string,
   jqFilter: string,
 }
 
 module.exports = {
-  command: 'validate <schema> [filename]',
-  description: 'validate newline-delimited json statements against the given schema. ' +
-    '`schema` can be either a path to a local schema, or the base58 object id of a published schema. ' +
-  'statements will be read from `filename` or stdin.\n',
+  command: 'validate [filename]',
+  description: 'Validate newline-delimited json objects against a schema. ' +
+  'Objects will be read from `filename` or stdin.\n',
   builder: {
+    schema: {
+      description: 'Either a path to a local schema, or the base58 object id of a published schema. ' +
+        'Required, unless --jsonld is present.\n',
+      type: 'string'
+    },
+    jsonld: {
+      description: 'If --jsonld is present, validate that inputs are structurally valid JSONLD.  ' +
+        'This does not ensure that they are semantically correct.\n',
+      type: 'boolean',
+      default: false,
+      defaultDescription: 'False.  Setting this flag will cause the --schema argument to be ignored.'
+    },
     jqFilter: {
       type: 'string',
       description: 'A jq filter to apply to input records as a pre-processing step. ' +
@@ -31,7 +44,8 @@ module.exports = {
   },
 
   handler: (opts: HandlerOptions) => {
-    const { apiUrl, schema, filename, jqFilter } = opts
+    const { apiUrl, filename, jqFilter, jsonld } = opts
+    let { schema } = opts
     let streamName = 'standard input'
 
     let stream: Readable
@@ -40,6 +54,17 @@ module.exports = {
       streamName = filename
     } else {
       stream = process.stdin
+    }
+
+    if (jsonld === true) {
+      schema = path.join(__dirname, '..', '..', '..', 'metadata', 'schemas',
+        'io.mediachain.jsonld-jsonschema-1-0-0.json')
+    }
+
+    if (schema == null) {
+      console.error('You must provide either the --schema or --jsonld arguments.')
+      process.exit(1)
+      return  // flow doesn't seem to recognize process.exit
     }
 
     let schemaPromise: Promise<SelfDescribingSchema>
@@ -83,12 +108,13 @@ function validateStream (opts: {
       const obj = JSON.parse(jsonString)
       const result = validate(schema, obj)
       if (!result.success) {
-        throw new Error(`${result.error.message}.\nFailed object:\n${jsonString}`)
+        console.error(`${result.error.message}.\nFailed object:\n${jsonString}`)
+        process.exit(1)
       }
       count += 1
     })
     .on('error', err => {
-      console.error(`Error reading from ${streamName}: `, err)
+      console.error(`Error reading from ${streamName}: `, err.message)
       process.exit(1)
     })
     .on('end', () => {

--- a/src/metadata/schemas/io.mediachain.jsonld-jsonschema-1-0-0.json
+++ b/src/metadata/schemas/io.mediachain.jsonld-jsonschema-1-0-0.json
@@ -1,0 +1,96 @@
+{
+    "title": "Schema for JSON-LD",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+
+    "self": {
+      "vendor": "io.mediachain",
+      "name": "jsonld",
+      "format": "jsonschema",
+      "version": "1-0-0"
+    },
+
+    "definitions":{
+        "context": {
+            "additionalProperties": true,
+            "properties": {
+                "@context": {
+                    "description": "Used to define the short-hand names that are used throughout a JSON-LD document.",
+                    "type": ["object", "string", "array", "null"]
+                }
+            }
+        },
+        "graph": {
+            "additionalProperties": true,
+            "properties": {
+                "@graph": {
+                    "description": "Used to express a graph.",
+                    "type": ["array", "object"],
+                    "additionalItems": {
+                        "anyOf": [{ "$ref": "#/definitions/common" }]
+                    }
+                }
+            }
+        },
+        "common":{
+            "additionalProperties": {
+                "anyOf": [{ "$ref": "#/definitions/common" }]
+            },
+            "properties": {
+                "@id": {
+                    "description": "Used to uniquely identify things that are being described in the document with IRIs or blank node identifiers.",
+                    "type": "string",
+                    "format": "uri"
+                },
+                "@value": {
+                    "description": "Used to specify the data that is associated with a particular property in the graph.",
+                    "type": ["string", "boolean", "number", "null"]
+                },
+                "@language": {
+                    "description": "Used to specify the language for a particular string value or the default language of a JSON-LD document.",
+                    "type": ["string", "null"]
+                },
+                "@type": {
+                    "description": "Used to set the data type of a node or typed value.",
+                    "type": ["string", "null", "array"]
+                },
+                "@container": {
+                    "description": "Used to set the default container type for a term.",
+                    "type": ["string", "null"],
+                    "enum": ["@list", "@index", "@set"]
+                },
+                "@list": {
+                    "description": "Used to express an ordered set of data."
+                },
+                "@set": {
+                    "description": "Used to express an unordered set of data and to ensure that values are always represented as arrays."
+                },
+                "@reverse": {
+                    "description": "Used to express reverse properties.",
+                    "type": ["string", "object", "null"],
+                    "additionalProperties": {
+                        "anyOf": [{ "$ref": "#/definitions/common" }]
+                    }
+                },
+                "@base": {
+                    "description": "Used to set the base IRI against which relative IRIs are resolved",
+                    "type": ["string", "null"],
+                    "format": "uri"
+                },
+                "@vocab": {
+                    "description": "Used to expand properties and values in @type with a common prefix IRI",
+                    "type": ["string", "null"],
+                    "format": "uri"
+                }
+            }
+        }
+    },
+
+    "allOf": [
+        { "$ref": "#/definitions/context" },
+        { "$ref": "#/definitions/graph" },
+        { "$ref": "#/definitions/common" }
+    ],
+
+    "type": ["object", "array"],
+    "additionalProperties": true
+}


### PR DESCRIPTION
This adds a jsonschema for structurally validating JSON-LD objects, and adds a `--jsonld` flag to the `mcclient validate` subcommand.  It also changes the `schema` argument for that command to be hyphenated (`--schema`) instead of a positional argument, and it's now mutually exclusive with `--jsonld`.  Running with `--jsonld` is equivalent to `--schema <pathToJsonldSchema>`

I haven't wired this up to the `publish` command yet, because to do it right we have to ensure that the jsonld schema has been published to the node before we publish the records.  That's certainly doable, but I just haven't implemented it yet.