### PR TITLE
Automatic SSH tunneling with Deploy credentials file

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "pull-stream": "3.5.0",
     "thenify": "https://registry.npmjs.org/thenify/-/thenify-3.2.1.tgz",
     "thenify-all": "^1.6.0",
+    "tunnel-ssh": "^4.1.1",
     "varint": "5.0.0",
     "yargs": "^6.3.0"
   },

--- a/src/client/api/index.js
+++ b/src/client/api/index.js
@@ -1,0 +1,4 @@
+
+module.exports = {
+  RestClient: require('./RestClient')
+}

--- a/src/client/cli/commands/auth/grant.js
+++ b/src/client/cli/commands/auth/grant.js
@@ -1,31 +1,24 @@
 // @flow
 
 const RestClient = require('../../../api/RestClient')
-const { printJSON } = require('../../util')
+const { subcommand, printJSON } = require('../../util')
 
 module.exports = {
-  command: 'grant <peerId> <namespaces>',
+  command: 'grant <peerId> <namespaces..>',
   description: 'Set the list of namespaces that a given peer can push to. ' +
     'This will replace any existing authorizations. ' +
     "Namespaces may include wildcards, e.g. 'images.*'\n",
   builder: (yargs: Object) => yargs
     .example('$0 auth grant QmZtSnkmB9DkKJ1L4V65XZZAJC2GyCdge7x2cGn9Z9NTBs images.dpla museums.*'),
-  handler: (opts: {apiUrl: string, peerId: string, namespaces: string, _: Array<string>}) => {
-    const {apiUrl, peerId} = opts
+  handler: subcommand((opts: {client: RestClient, peerId: string, namespaces: Array<string>}) => {
+    const {client, peerId, namespaces} = opts
 
-    // This is an ugly hack to work around yargs unfortunate handling of
-    // positional args in subcommands... the `opts._` array includes
-    // the 'auth' and 'set' subcommand strings
-    const additionalNamespaces = opts._.slice(2, opts._.length)
-    const namespaces = [opts.namespaces].concat(additionalNamespaces)
-
-    const client = new RestClient({apiUrl})
-    client.authorize(peerId, namespaces)
+    return client.authorize(peerId, namespaces)
       .then(() => client.getAuthorizations())
       .then(auths => {
         console.log(`Granted authorizations for peer ${peerId}:`)
         printJSON(auths[peerId])
       })
       .catch(err => console.error(err.message))
-  }
+  })
 }

--- a/src/client/cli/commands/auth/grant.js
+++ b/src/client/cli/commands/auth/grant.js
@@ -19,6 +19,5 @@ module.exports = {
         console.log(`Granted authorizations for peer ${peerId}:`)
         printJSON(auths[peerId])
       })
-      .catch(err => console.error(err.message))
   })
 }

--- a/src/client/cli/commands/auth/revoke.js
+++ b/src/client/cli/commands/auth/revoke.js
@@ -11,6 +11,5 @@ module.exports = {
     const client = new RestClient({apiUrl})
     return client.revokeAuthorization(peerId)
       .then(() => { console.log(`Revoked authorization for ${peerId}.`) })
-      .catch(err => { console.error(err.message) })
   })
 }

--- a/src/client/cli/commands/auth/revoke.js
+++ b/src/client/cli/commands/auth/revoke.js
@@ -1,15 +1,16 @@
 // @flow
 
 const RestClient = require('../../../api/RestClient')
+const { subcommand } = require('../../util')
 
 module.exports = {
   command: 'revoke <peerId>',
   description: 'Revoke all authorizations for the given peer.\n',
-  handler: (opts: {apiUrl: string, peerId: string}) => {
+  handler: subcommand((opts: {apiUrl: string, peerId: string}) => {
     const {apiUrl, peerId} = opts
     const client = new RestClient({apiUrl})
-    client.revokeAuthorization(peerId)
+    return client.revokeAuthorization(peerId)
       .then(() => { console.log(`Revoked authorization for ${peerId}.`) })
       .catch(err => { console.error(err.message) })
-  }
+  })
 }

--- a/src/client/cli/commands/auth/show.js
+++ b/src/client/cli/commands/auth/show.js
@@ -10,6 +10,5 @@ module.exports = {
     const {client} = opts
     return client.getAuthorizations()
       .then(authInfo => printJSON(authInfo))
-      .catch(err => console.error(err.message))
   })
 }

--- a/src/client/cli/commands/auth/show.js
+++ b/src/client/cli/commands/auth/show.js
@@ -1,16 +1,15 @@
 // @flow
 
 const RestClient = require('../../../api/RestClient')
-const { printJSON } = require('../../util')
+const { subcommand, printJSON } = require('../../util')
 
 module.exports = {
   command: 'show',
   description: 'Show the peers authorized to push data to the local node.\n',
-  handler: (opts: {apiUrl: string}) => {
-    const {apiUrl} = opts
-    const client = new RestClient({apiUrl})
-    client.getAuthorizations()
+  handler: subcommand((opts: {client: RestClient}) => {
+    const {client} = opts
+    return client.getAuthorizations()
       .then(authInfo => printJSON(authInfo))
       .catch(err => console.error(err.message))
-  }
+  })
 }

--- a/src/client/cli/commands/config/dir.js
+++ b/src/client/cli/commands/config/dir.js
@@ -1,15 +1,15 @@
 // @flow
 
 const RestClient = require('../../../api/RestClient')
+const { subcommand } = require('../../util')
 
 module.exports = {
   command: 'dir [dirId]',
   description: 'Get or set the directory server id.\n',
-  handler: (opts: {apiUrl: string, dirId?: string}) => {
-    const {apiUrl, dirId} = opts
-    const client = new RestClient({apiUrl})
+  handler: subcommand((opts: {client: RestClient, dirId?: string}) => {
+    const {client, dirId} = opts
     if (dirId) {
-      client.setDirectoryId(dirId)
+      return client.setDirectoryId(dirId)
         .then(() => {
           console.log(`set directory to ${dirId}`)
         })
@@ -20,5 +20,5 @@ module.exports = {
           err => console.error(err.message)
         )
     }
-  }
+  })
 }

--- a/src/client/cli/commands/config/dir.js
+++ b/src/client/cli/commands/config/dir.js
@@ -15,10 +15,7 @@ module.exports = {
         })
     } else {
       return client.getDirectoryId()
-        .then(
-          console.log,
-          err => console.error(err.message)
-        )
+        .then(console.log)
     }
   })
 }

--- a/src/client/cli/commands/config/info.js
+++ b/src/client/cli/commands/config/info.js
@@ -1,15 +1,15 @@
 // @flow
 
 const RestClient = require('../../../api/RestClient')
+const { subcommand } = require('../../util')
 
 module.exports = {
   command: 'info [peerInfo]',
   description: 'Get or set the peer info message.\n',
-  handler: (opts: {apiUrl: string, peerInfo?: string}) => {
-    const {apiUrl, peerInfo} = opts
-    const client = new RestClient({apiUrl})
+  handler: subcommand((opts: {client: RestClient, peerInfo?: string}) => {
+    const {client, peerInfo} = opts
     if (peerInfo) {
-      client.setInfo(peerInfo)
+      return client.setInfo(peerInfo)
         .then(() => {
           console.log(`set peer info to "${peerInfo}"`)
         })
@@ -20,5 +20,5 @@ module.exports = {
           err => console.error(err.message)
         )
     }
-  }
+  })
 }

--- a/src/client/cli/commands/config/info.js
+++ b/src/client/cli/commands/config/info.js
@@ -15,10 +15,7 @@ module.exports = {
         })
     } else {
       return client.getInfo()
-        .then(
-          console.log,
-          err => console.error(err.message)
-        )
+        .then(console.log)
     }
   })
 }

--- a/src/client/cli/commands/config/nat.js
+++ b/src/client/cli/commands/config/nat.js
@@ -14,14 +14,11 @@ module.exports = {
           console.log(`set NAT configuration to "${natConfig}"`)
         })
         .catch(err => {
-          console.error('Error setting NAT configuration: ', err.message)
+          throw new Error(`Error setting NAT configuration: ${err.message}`)
         })
     } else {
       return client.getNATConfig()
-        .then(
-          console.log,
-          err => console.error(err.message)
-        )
+        .then(console.log)
     }
   })
 }

--- a/src/client/cli/commands/config/nat.js
+++ b/src/client/cli/commands/config/nat.js
@@ -1,15 +1,15 @@
 // @flow
 
 const RestClient = require('../../../api/RestClient')
+const { subcommand } = require('../../util')
 
 module.exports = {
   command: 'nat [natConfig]',
   description: `Get or set the NAT configuration. Valid settings are 'none', 'auto', '*', '*:port', 'ip:port'. \n`,
-  handler: (opts: {apiUrl: string, natConfig?: string}) => {
-    const {apiUrl, natConfig} = opts
-    const client = new RestClient({apiUrl})
+  handler: subcommand((opts: {client: RestClient, natConfig?: string}) => {
+    const {client, natConfig} = opts
     if (natConfig) {
-      client.setNATConfig(natConfig)
+      return client.setNATConfig(natConfig)
         .then(() => {
           console.log(`set NAT configuration to "${natConfig}"`)
         })
@@ -23,5 +23,5 @@ module.exports = {
           err => console.error(err.message)
         )
     }
-  }
+  })
 }

--- a/src/client/cli/commands/delete.js
+++ b/src/client/cli/commands/delete.js
@@ -1,19 +1,18 @@
 // @flow
 
 const RestClient = require('../../api/RestClient')
-const { pluralizeCount } = require('../util')
+const { subcommand, pluralizeCount } = require('../util')
 
 module.exports = {
   command: 'delete <queryString>',
   description: 'Send a delete query to the local node to delete matching statements.\n',
-  handler: (opts: {apiUrl: string, queryString: string}) => {
-    const {apiUrl, queryString} = opts
+  handler: subcommand((opts: {client: RestClient, queryString: string}) => {
+    const {client, queryString} = opts
 
-    const client = new RestClient({apiUrl})
-    client.delete(queryString)
+    return client.delete(queryString)
       .then(count => {
         console.log(`Deleted ${pluralizeCount(count, 'statement')}`)
       })
       .catch(err => console.error(err.message))
-  }
+  })
 }

--- a/src/client/cli/commands/delete.js
+++ b/src/client/cli/commands/delete.js
@@ -13,6 +13,5 @@ module.exports = {
       .then(count => {
         console.log(`Deleted ${pluralizeCount(count, 'statement')}`)
       })
-      .catch(err => console.error(err.message))
   })
 }

--- a/src/client/cli/commands/getData.js
+++ b/src/client/cli/commands/getData.js
@@ -32,8 +32,7 @@ module.exports = {
           } else {
             printJSON(obj, {color, pretty})
           }
-        },
-        err => console.error(err.message)
+        }
       )
   })
 }

--- a/src/client/cli/commands/getData.js
+++ b/src/client/cli/commands/getData.js
@@ -22,7 +22,7 @@ module.exports = {
   },
 
   handler: subcommand((opts: {client: RestClient, objectId: string, color: ?boolean, pretty: boolean}) => {
-    const {objectId, color, pretty} = opts
+    const {client, objectId, color, pretty} = opts
 
     return client.getData(objectId)
       .then(

--- a/src/client/cli/commands/getData.js
+++ b/src/client/cli/commands/getData.js
@@ -1,7 +1,7 @@
 // @flow
 
 const RestClient = require('../../api/RestClient')
-const { printJSON } = require('../util')
+const { printJSON, subcommand } = require('../util')
 
 module.exports = {
   command: 'getData <objectId>',
@@ -21,11 +21,10 @@ module.exports = {
     }
   },
 
-  handler: (opts: {apiUrl: string, objectId: string, color: ?boolean, pretty: boolean}) => {
-    const {apiUrl, objectId, color, pretty} = opts
-    const client = new RestClient({apiUrl})
+  handler: subcommand((opts: {client: RestClient, objectId: string, color: ?boolean, pretty: boolean}) => {
+    const {objectId, color, pretty} = opts
 
-    client.getData(objectId)
+    return client.getData(objectId)
       .then(
         obj => {
           if (obj instanceof Buffer) {
@@ -36,5 +35,5 @@ module.exports = {
         },
         err => console.error(err.message)
       )
-  }
+  })
 }

--- a/src/client/cli/commands/id.js
+++ b/src/client/cli/commands/id.js
@@ -1,19 +1,19 @@
 // @flow
 
 const RestClient = require('../../api/RestClient')
+const {subcommand} = require('../util')
 
 module.exports = {
   command: 'id [peerId]',
   description: 'Request the peer id, publisher id, and info string of the local node, ' +
     'or a remote peer if `peerId` is given and a directory server is connected.\n',
-  handler: (opts: {apiUrl: string, peerId?: string}) => {
-    const {apiUrl, peerId} = opts
-    const client = new RestClient({apiUrl})
-    client.id(peerId).then(
+  handler: subcommand((opts: {client: RestClient, peerId?: string}) => {
+    const {client, peerId} = opts
+    return client.id(peerId).then(
       printIds,
       err => { console.error(err.message) }
     )
-  }
+  })
 }
 
 function printIds (opts: {peer: string, publisher: string, info: string}) {

--- a/src/client/cli/commands/id.js
+++ b/src/client/cli/commands/id.js
@@ -9,10 +9,8 @@ module.exports = {
     'or a remote peer if `peerId` is given and a directory server is connected.\n',
   handler: subcommand((opts: {client: RestClient, peerId?: string}) => {
     const {client, peerId} = opts
-    return client.id(peerId).then(
-      printIds,
-      err => { console.error(err.message) }
-    )
+    return client.id(peerId)
+      .then(printIds)
   })
 }
 

--- a/src/client/cli/commands/listPeers.js
+++ b/src/client/cli/commands/listPeers.js
@@ -1,6 +1,7 @@
 // @flow
 
 const RestClient = require('../../api/RestClient')
+const { subcommand } = require('../util')
 
 module.exports = {
   command: 'listPeers',
@@ -14,33 +15,36 @@ module.exports = {
   },
   description: `Fetch a list of remote peers from the directory server. The local node must be ` +
     `configured to use a directory server.\n`,
-  handler: (opts: {apiUrl: string, info: boolean}) => {
-    const {apiUrl, info} = opts
-    const client = new RestClient({apiUrl})
-    client.listPeers().then(
+  handler: subcommand((opts: {client: RestClient, info: boolean}) => {
+    const {client, info} = opts
+    return client.listPeers().then(
       peers => {
         if (info) {
-          fetchInfos(client, peers)
+          return fetchInfos(client, peers)
         } else {
           peers.forEach(p => console.log(p))
         }
       },
       err => { console.error(err.message) }
     )
-  }
+  })
 }
 
-function fetchInfos (client: RestClient, peerIds: Array<string>) {
+function fetchInfos (client: RestClient, peerIds: Array<string>): Promise<*> {
+  const promises: Array<Promise<*>> = []
   for (const peer of peerIds) {
-    client.id(peer)
-      .then(ids => {
-        let msg = 'No info published'
-        if (ids.info != null && ids.info.length > 0) {
-          msg = ids.info
-        }
-        return peer + ` -- ${msg}`
-      })
-      .catch(err => `${peer} -- Unable to fetch info: ${err.message}`)
-      .then(console.log)
+    promises.push(
+      client.id(peer)
+        .then(ids => {
+          let msg = 'No info published'
+          if (ids.info != null && ids.info.length > 0) {
+            msg = ids.info
+          }
+          return peer + ` -- ${msg}`
+        })
+        .catch(err => `${peer} -- Unable to fetch info: ${err.message}`)
+        .then(console.log)
+    )
   }
+  return Promise.all(promises)
 }

--- a/src/client/cli/commands/listPeers.js
+++ b/src/client/cli/commands/listPeers.js
@@ -24,8 +24,7 @@ module.exports = {
         } else {
           peers.forEach(p => console.log(p))
         }
-      },
-      err => { console.error(err.message) }
+      }
     )
   })
 }

--- a/src/client/cli/commands/merge.js
+++ b/src/client/cli/commands/merge.js
@@ -1,23 +1,22 @@
 // @flow
 
 const RestClient = require('../../api/RestClient')
-const { pluralizeCount } = require('../util')
+const { subcommand, pluralizeCount } = require('../util')
 
 module.exports = {
   command: 'merge <remotePeer> <queryString>',
   description: 'Merge statements and their referenced objects that match `query` from ' +
     '`remotePeer` into the local node.\n',
-  handler: (opts: {apiUrl: string, queryString: string, remotePeer: string}) => {
-    const {apiUrl, queryString, remotePeer} = opts
+  handler: subcommand((opts: {client: RestClient, queryString: string, remotePeer: string}) => {
+    const {client, queryString, remotePeer} = opts
 
-    const client = new RestClient({apiUrl})
-    client.merge(queryString, remotePeer)
+    return client.merge(queryString, remotePeer)
       .then(({statementCount, objectCount}) => {
         console.log(
           `merged ${pluralizeCount(statementCount, 'statement')} and ${pluralizeCount(objectCount, 'object')}`
         )
       })
       .catch(err => console.error(err.message))
-  }
+  })
 }
 

--- a/src/client/cli/commands/merge.js
+++ b/src/client/cli/commands/merge.js
@@ -16,7 +16,6 @@ module.exports = {
           `merged ${pluralizeCount(statementCount, 'statement')} and ${pluralizeCount(objectCount, 'object')}`
         )
       })
-      .catch(err => console.error(err.message))
   })
 }
 

--- a/src/client/cli/commands/netAddr.js
+++ b/src/client/cli/commands/netAddr.js
@@ -21,8 +21,9 @@ module.exports = {
               console.log(addr)
             })
           }
-        },
-        err => console.error('Error retrieving addresses: ', err.message)
+        })
+      .catch(
+        err => { throw new Error(`Error retrieving addresses: ${err.message}`) }
       )
   })
 }

--- a/src/client/cli/commands/netAddr.js
+++ b/src/client/cli/commands/netAddr.js
@@ -1,15 +1,15 @@
 // @flow
 
 const RestClient = require('../../api/RestClient')
+const { subcommand } = require('../util')
 
 module.exports = {
   command: 'netAddr',
   describe: `Print the local node's network addresses in multiaddr format.\n`,
-  handler: (opts: {apiUrl: string}) => {
-    const {apiUrl} = opts
+  handler: subcommand((opts: {client: RestClient}) => {
+    const {client} = opts
 
-    const client = new RestClient({apiUrl})
-    client.getNetAddresses()
+    return client.getNetAddresses()
       .then(
         addresses => {
           if (addresses.length < 1) {
@@ -24,5 +24,5 @@ module.exports = {
         },
         err => console.error('Error retrieving addresses: ', err.message)
       )
-  }
+  })
 }

--- a/src/client/cli/commands/ping.js
+++ b/src/client/cli/commands/ping.js
@@ -1,20 +1,20 @@
 // @flow
 
 const RestClient = require('../../api/RestClient')
+const { subcommand } = require('../util')
 
 module.exports = {
   command: 'ping <peerId>',
   describe: 'Ping a remote peer, identified by `peerId`. ' +
   'The local node must be configured to use a directory server.\n',
-  handler: (opts: {peerId: string, apiUrl: string}) => {
-    const {peerId, apiUrl} = opts
+  handler: subcommand((opts: {peerId: string, client: RestClient}) => {
+    const {peerId, client} = opts
     console.log('pinging peer: ', peerId)
 
-    const client = new RestClient({apiUrl})
-    client.ping(peerId)
+    return client.ping(peerId)
       .then(
         success => console.log(`ping OK`),
         err => console.error('error pinging: ', err.message)
       )
-  }
+  })
 }

--- a/src/client/cli/commands/ping.js
+++ b/src/client/cli/commands/ping.js
@@ -9,12 +9,12 @@ module.exports = {
   'The local node must be configured to use a directory server.\n',
   handler: subcommand((opts: {peerId: string, client: RestClient}) => {
     const {peerId, client} = opts
-    console.log('pinging peer: ', peerId)
+    console.log('Pinging peer: ', peerId)
 
     return client.ping(peerId)
       .then(
-        success => console.log(`ping OK`),
-        err => console.error('error pinging: ', err.message)
+        success => console.log('Ping OK'),
+        err => { throw new Error(`Error pinging: ${err.message}`) }
       )
   })
 }

--- a/src/client/cli/commands/publish.js
+++ b/src/client/cli/commands/publish.js
@@ -116,10 +116,6 @@ module.exports = {
           schema,
           jqFilter: composeJQFilters(jqFilter, idFilter)})
       )
-      .catch(err => {
-        console.error(err.message)
-        process.exit(1)
-      })
   })
 }
 
@@ -236,14 +232,10 @@ function publishStream (opts: {
             }
             resolve()
           })
-          .catch(err => {
-            console.error('Error publishing statements: ', err.message)
-            reject(err)
-          })
+          .catch(reject)
       })
       .on('error', err => {
-        console.error(`Error reading from ${streamName}: `, err)
-        reject(err)
+        reject(new Error(`Error reading from ${streamName}: ${err.message}`))
       })
   })
 }

--- a/src/client/cli/commands/publishRaw.js
+++ b/src/client/cli/commands/publishRaw.js
@@ -1,6 +1,7 @@
 // @flow
 
 const RestClient = require('../../api/RestClient')
+const { subcommand } = require('../util')
 
 module.exports = {
   command: 'publishRaw <namespace> <statementBodyId>',
@@ -8,14 +9,13 @@ module.exports = {
     'already been stored in the node.  `statementBodyId` should be the multihash ' +
     'identifier of the statement body.\n',
 
-  handler: (opts: {namespace: string, apiUrl: string, statementBodyId: string}) => {
-    const {namespace, apiUrl, statementBodyId} = opts
-    const client = new RestClient({apiUrl})
+  handler: subcommand((opts: {client: RestClient, namespace: string, statementBodyId: string}) => {
+    const {client, namespace, statementBodyId} = opts
 
-    client.publish({namespace}, {object: statementBodyId})
+    return client.publish({namespace}, {object: statementBodyId})
       .then(
         console.log,
         err => console.error(err.message)
       )
-  }
+  })
 }

--- a/src/client/cli/commands/publishRaw.js
+++ b/src/client/cli/commands/publishRaw.js
@@ -13,9 +13,6 @@ module.exports = {
     const {client, namespace, statementBodyId} = opts
 
     return client.publish({namespace}, {object: statementBodyId})
-      .then(
-        console.log,
-        err => console.error(err.message)
-      )
+      .then(console.log)
   })
 }

--- a/src/client/cli/commands/publishSchema.js
+++ b/src/client/cli/commands/publishSchema.js
@@ -31,6 +31,5 @@ module.exports = {
             console.log(`Object ID: ${objectId}`)
             console.log(`Statement ID: ${statementId}`)
           }))
-      .catch(err => console.error(err.message))
   })
 }

--- a/src/client/cli/commands/publishSchema.js
+++ b/src/client/cli/commands/publishSchema.js
@@ -1,6 +1,7 @@
 // @flow
 
 const RestClient = require('../../api/RestClient')
+const { subcommand } = require('../util')
 const { loadSelfDescribingSchema, schemaDescriptionToWKI } = require('../../../metadata/schema')
 
 const SCHEMA_NAMESPACE = 'mediachain.schemas'
@@ -16,14 +17,13 @@ module.exports = {
     }
   },
 
-  handler: (opts: {apiUrl: string, schemaName: string, version: string, filename: string, namespace: string}) => {
-    const {apiUrl, filename, namespace} = opts
-    const client = new RestClient({apiUrl})
+  handler: subcommand((opts: {client: RestClient, schemaName: string, version: string, filename: string, namespace: string}) => {
+    const {client, filename, namespace} = opts
 
     const schema = loadSelfDescribingSchema(filename)
     const wki = schemaDescriptionToWKI(schema.self)
 
-    client.putData(schema)
+    return client.putData(schema)
       .then(([objectId]) =>
         client.publish({namespace}, {object: objectId, refs: [wki]})
           .then(([statementId]) => {
@@ -32,5 +32,5 @@ module.exports = {
             console.log(`Statement ID: ${statementId}`)
           }))
       .catch(err => console.error(err.message))
-  }
+  })
 }

--- a/src/client/cli/commands/push.js
+++ b/src/client/cli/commands/push.js
@@ -1,24 +1,23 @@
 // @flow
 
 const RestClient = require('../../api/RestClient')
-const { pluralizeCount } = require('../util')
+const { subcommand, pluralizeCount } = require('../util')
 
 module.exports = {
   command: 'push <remotePeer> <queryString>',
   description: 'Push statements and their referenced objects that match `query` to ' +
   '`remotePeer` from the local node.  The local node must be authorized with the remote ' +
   ' peer for the namespaces you are pushing to. \n',
-  handler: (opts: {apiUrl: string, queryString: string, remotePeer: string}) => {
-    const {apiUrl, queryString, remotePeer} = opts
+  handler: subcommand((opts: {client: RestClient, queryString: string, remotePeer: string}) => {
+    const {client, queryString, remotePeer} = opts
 
-    const client = new RestClient({apiUrl})
-    client.push(queryString, remotePeer)
+    return client.push(queryString, remotePeer)
       .then(({statementCount, objectCount}) => {
         console.log(
           `Pushed ${pluralizeCount(statementCount, 'statement')} and ${pluralizeCount(objectCount, 'object')}`
         )
       })
       .catch(err => console.error(err.message))
-  }
+  })
 }
 

--- a/src/client/cli/commands/push.js
+++ b/src/client/cli/commands/push.js
@@ -17,7 +17,6 @@ module.exports = {
           `Pushed ${pluralizeCount(statementCount, 'statement')} and ${pluralizeCount(objectCount, 'object')}`
         )
       })
-      .catch(err => console.error(err.message))
   })
 }
 

--- a/src/client/cli/commands/putData.js
+++ b/src/client/cli/commands/putData.js
@@ -46,7 +46,7 @@ module.exports = {
             .then(() => resolve())
         })
         .on('error', err => {
-          console.error(`Error reading from ${streamName}: `, err)
+          err = new Error(`Error reading from ${streamName}: ${err.message}`)
           reject(err)
         })
     })
@@ -57,7 +57,6 @@ function putItems (client: RestClient, items: Array<Object>): Promise<*> {
   return client.putData(...items).then(
     hashes => {
       hashes.forEach(h => console.log(h))
-    },
-    err => console.error(err.message)
+    }
   )
 }

--- a/src/client/cli/commands/query.js
+++ b/src/client/cli/commands/query.js
@@ -36,6 +36,5 @@ module.exports = {
           .on('end', resolve)
           .on('error', reject)
       }))
-      .catch(err => console.error(err.message))
   })
 }

--- a/src/client/cli/commands/shutdown.js
+++ b/src/client/cli/commands/shutdown.js
@@ -1,16 +1,16 @@
 // @flow
 
 const RestClient = require('../../api/RestClient')
+const { subcommand } = require('../util')
 
 module.exports = {
   command: 'shutdown',
   description: 'Tell the local node to shutdown.\n',
-  handler: (opts: {apiUrl: string}) => {
-    const {apiUrl} = opts
-    const client = new RestClient({apiUrl})
-    client.shutdown().then(
+  handler: subcommand((opts: {client: RestClient}) => {
+    const {client} = opts
+    return client.shutdown().then(
       console.log('Node shutdown successfully'),
       err => { console.error(err.message) }
     )
-  }
+  })
 }

--- a/src/client/cli/commands/shutdown.js
+++ b/src/client/cli/commands/shutdown.js
@@ -9,8 +9,7 @@ module.exports = {
   handler: subcommand((opts: {client: RestClient}) => {
     const {client} = opts
     return client.shutdown().then(
-      console.log('Node shutdown successfully'),
-      err => { console.error(err.message) }
+      console.log('Node shutdown successfully')
     )
   })
 }

--- a/src/client/cli/commands/statement.js
+++ b/src/client/cli/commands/statement.js
@@ -1,7 +1,7 @@
 // @flow
 
 const RestClient = require('../../api/RestClient')
-const { printJSON } = require('../util')
+const { subcommand, printJSON } = require('../util')
 
 module.exports = {
   command: 'statement <statementId>',
@@ -21,14 +21,13 @@ module.exports = {
     }
   },
 
-  handler: (opts: {statementId: string, apiUrl: string, color: ?boolean, pretty: boolean}) => {
-    const {statementId, apiUrl, color, pretty} = opts
-    const client = new RestClient({apiUrl})
+  handler: subcommand((opts: {client: RestClient, statementId: string, color: ?boolean, pretty: boolean}) => {
+    const {client, statementId, color, pretty} = opts
 
-    client.statement(statementId)
+    return client.statement(statementId)
       .then(
         obj => { printJSON(obj, {color, pretty}) },
         err => { console.error(err.message) }
       )
-  }
+  })
 }

--- a/src/client/cli/commands/statement.js
+++ b/src/client/cli/commands/statement.js
@@ -25,9 +25,6 @@ module.exports = {
     const {client, statementId, color, pretty} = opts
 
     return client.statement(statementId)
-      .then(
-        obj => { printJSON(obj, {color, pretty}) },
-        err => { console.error(err.message) }
-      )
+      .then(obj => { printJSON(obj, {color, pretty}) })
   })
 }

--- a/src/client/cli/commands/status.js
+++ b/src/client/cli/commands/status.js
@@ -24,13 +24,13 @@ module.exports = {
         status = newStatus
         break
       default:
-        console.error(`Cannot set status to ${newStatus}. Must be one of: online, offline, public`)
-        return Promise.resolve()
+        return Promise.reject(
+          new Error(`Cannot set status to ${newStatus}. Must be one of: online, offline, public`)
+        )
     }
     return client.setStatus(status)
-      .then(
-        returnedStatus => console.log(`status set to ${returnedStatus}`),
-        err => console.error(err.message)
-      )
+      .then(returnedStatus => {
+        console.log(`status set to ${returnedStatus}`)
+      })
   })
 }

--- a/src/client/cli/commands/status.js
+++ b/src/client/cli/commands/status.js
@@ -1,6 +1,7 @@
 // @flow
 
 const RestClient = require('../../api/RestClient')
+const { subcommand } = require('../util')
 import type { NodeStatus } from '../../api/RestClient'
 
 module.exports = {
@@ -8,9 +9,8 @@ module.exports = {
   description: 'Get or set the status of the local node. ' +
     'If `newStatus` is not given, returns the current status. ' +
     '`newStatus` must be one of: online, offline, public\n',
-  handler: (opts: {apiUrl: string, newStatus?: string}) => {
-    const {apiUrl, newStatus} = opts
-    const client = new RestClient({apiUrl})
+  handler: subcommand((opts: {client: RestClient, newStatus?: string}) => {
+    const {client, newStatus} = opts
 
     if (!newStatus) {
       return client.getStatus().then(console.log)
@@ -27,10 +27,10 @@ module.exports = {
         console.error(`Cannot set status to ${newStatus}. Must be one of: online, offline, public`)
         return
     }
-    client.setStatus(status)
+    return client.setStatus(status)
       .then(
         returnedStatus => console.log(`status set to ${returnedStatus}`),
         err => console.error(err.message)
       )
-  }
+  })
 }

--- a/src/client/cli/commands/status.js
+++ b/src/client/cli/commands/status.js
@@ -25,7 +25,7 @@ module.exports = {
         break
       default:
         console.error(`Cannot set status to ${newStatus}. Must be one of: online, offline, public`)
-        return
+        return Promise.resolve()
     }
     return client.setStatus(status)
       .then(

--- a/src/client/cli/commands/validate.js
+++ b/src/client/cli/commands/validate.js
@@ -64,7 +64,7 @@ module.exports = {
     if (schema == null) {
       console.error('You must provide either the --schema or --jsonld arguments.')
       process.exit(1)
-      return  // flow doesn't seem to recognize process.exit
+      return Promise.resolve() // flow doesn't seem to recognize process.exit
     }
 
     let schemaPromise: Promise<SelfDescribingSchema>
@@ -74,7 +74,7 @@ module.exports = {
       schemaPromise = Promise.resolve(loadSelfDescribingSchema(schema))
     }
 
-    schemaPromise.then(schema =>
+    return schemaPromise.then(schema =>
       validateStream({
         stream,
         streamName,

--- a/src/client/cli/index.js
+++ b/src/client/cli/index.js
@@ -12,7 +12,7 @@ yargs
     default: 'http://localhost:9002'
   })
   .option('deployCredentialsFile', {
-    description: 'Path to a credentials file created by Mediachain Deploy',
+    description: 'Path to a credentials file created by Mediachain Deploy'
   })
   .global('apiUrl')
   .global('deployCredentialsFile')

--- a/src/client/cli/index.js
+++ b/src/client/cli/index.js
@@ -2,8 +2,7 @@
 
 const yargs = require('yargs')
 
-const {sshTunnelFromDeployCredentialsFile} = require('./util')
-let sshTunnel = null
+const {deployCredsToTunnelConfig} = require('./util')
 
 yargs
   .usage('Usage: $0 [options] <command> [command-options]')
@@ -15,25 +14,13 @@ yargs
     default: 'http://localhost:9002'
   })
   .option('deployCredentialsFile', {
-    coerce: (filePath) => {
-      if (sshTunnel != null) return filePath
-      console.log('in coerce')
-      sshTunnel = sshTunnelFromDeployCredentialsFile(filePath)
-      return filePath
-    },
-    alias: 'sshTunnel'
+    coerce: deployCredsToTunnelConfig,
+    alias: 'sshTunnelConfig'
   })
   .global('apiUrl')
-  .global('sshTunnel')
+  .global('sshTunnelConfig')
   .commandDir('commands')
   .strict()
   .wrap(yargs.terminalWidth())
   .argv
 
-
-if (sshTunnel != null) {
-  sshTunnel.then(tunnel => {
-    console.log('ssh tunnel setup, closing')
-    tunnel.close()
-  })
-}

--- a/src/client/cli/index.js
+++ b/src/client/cli/index.js
@@ -11,11 +11,11 @@ yargs
     description: 'Root URL of the REST API for a mediachain node',
     default: 'http://localhost:9002'
   })
-  .option('deployCredentialsFile', {
-    description: 'Path to a credentials file created by Mediachain Deploy'
+  .option('sshConfig', {
+    description: 'Path to a configuration file for SSH tunnelling, e.g. the credentials file created by Mediachain Deploy'
   })
   .global('apiUrl')
-  .global('deployCredentialsFile')
+  .global('sshConfig')
   .commandDir('commands')
   .strict()
   .wrap(yargs.terminalWidth())

--- a/src/client/cli/index.js
+++ b/src/client/cli/index.js
@@ -2,8 +2,6 @@
 
 const yargs = require('yargs')
 
-const {deployCredsToTunnelConfig} = require('./util')
-
 yargs
   .usage('Usage: $0 [options] <command> [command-options]')
   .help()
@@ -14,11 +12,10 @@ yargs
     default: 'http://localhost:9002'
   })
   .option('deployCredentialsFile', {
-    coerce: deployCredsToTunnelConfig,
-    alias: 'sshTunnelConfig'
+    description: 'Path to a credentials file created by Mediachain Deploy',
   })
   .global('apiUrl')
-  .global('sshTunnelConfig')
+  .global('deployCredentialsFile')
   .commandDir('commands')
   .strict()
   .wrap(yargs.terminalWidth())

--- a/src/client/cli/index.js
+++ b/src/client/cli/index.js
@@ -2,6 +2,9 @@
 
 const yargs = require('yargs')
 
+const {sshTunnelFromDeployCredentialsFile} = require('./util')
+let sshTunnel = null
+
 yargs
   .usage('Usage: $0 [options] <command> [command-options]')
   .help()
@@ -11,8 +14,26 @@ yargs
     description: 'Root URL of the REST API for a mediachain node',
     default: 'http://localhost:9002'
   })
+  .option('deployCredentialsFile', {
+    coerce: (filePath) => {
+      if (sshTunnel != null) return filePath
+      console.log('in coerce')
+      sshTunnel = sshTunnelFromDeployCredentialsFile(filePath)
+      return filePath
+    },
+    alias: 'sshTunnel'
+  })
   .global('apiUrl')
+  .global('sshTunnel')
   .commandDir('commands')
   .strict()
   .wrap(yargs.terminalWidth())
   .argv
+
+
+if (sshTunnel != null) {
+  sshTunnel.then(tunnel => {
+    console.log('ssh tunnel setup, closing')
+    tunnel.close()
+  })
+}

--- a/src/client/cli/util.js
+++ b/src/client/cli/util.js
@@ -111,11 +111,13 @@ function subcommand<T: SubcommandGlobalOptions> (handler: (argv: T) => Promise<*
       ? deployCredsToTunnelConfig(deployCredentialsFile)
       : null
 
-    let sshTunnelPromise = Promise.resolve()
+    let sshTunnelPromise
     let sshTunnel = null
     if (sshTunnelConfig != null) {
       sshTunnelPromise = setupSSHTunnel(sshTunnelConfig)
         .then(tunnel => { sshTunnel = tunnel })
+    } else {
+      sshTunnelPromise = Promise.resolve()
     }
 
     function closeTunnel () {

--- a/src/client/cli/util.js
+++ b/src/client/cli/util.js
@@ -94,7 +94,7 @@ function deployCredsToTunnelConfig (deployCreds: Object | string, extraConfigOpt
 
 type GlobalOptions = {
   apiUrl: string,
-  sshTunnelConfig?: Object
+  deployCredentialsFile?: Object
 }
 
 type SubcommandGlobalOptions = {
@@ -103,8 +103,12 @@ type SubcommandGlobalOptions = {
 
 function subcommand (handler: (argv: SubcommandGlobalOptions) => Promise<*>): (argv: GlobalOptions) => void {
   return (argv: GlobalOptions) => {
-    const {apiUrl, sshTunnelConfig} = argv
+    const {apiUrl, deployCredentialsFile} = argv
     const client = new RestClient({apiUrl})
+
+    const sshTunnelConfig = (deployCredentialsFile != null)
+      ? deployCredsToTunnelConfig(deployCredentialsFile)
+      : null
 
     let sshTunnelPromise = Promise.resolve()
     let sshTunnel = null

--- a/src/client/cli/util.js
+++ b/src/client/cli/util.js
@@ -132,7 +132,8 @@ function subcommand<T: SubcommandGlobalOptions> (handler: (argv: T) => Promise<*
       .then(closeTunnel)
       .catch(err => {
         closeTunnel()
-        throw err
+        console.error(err.message)
+        process.exit(1)
       })
   }
 }


### PR DESCRIPTION
This adds a `--deployCredentialsFile` option that you can point at the file downloaded at the end of the Deploy process.  If given, it will create an SSH tunnel for you to the remote machine, using the ip address, username and password from the file. It uses a javascript SSH implementation, so it should work on Windows.

To get this to work, I made a `subcommand` helper function that wraps each subcommand handler.  If an SSH config is given, it creates the tunnel, runs the handler, then closes the tunnel afterwards.  The subcommand handler functions had to be tweaked slightly to return a `Promise`, which the wrapper waits on before closing the tunnel.

I also made the `subcommand` helper create the `RestClient` instance, so subcommands can just pull the `client` member out of their options object, instead of grabbing `apiUrl` and creating a `RestClient`.  That may come in handy if we ever add more options to the `RestClient` constructor, since we can just update it in one place.

example:

```
mcclient --deployCredentialsFile ~/Downloads/mediachain_node_138.68.24.97.yaml id
Peer ID: QmcrFvafCC64F44vhzv2JsYLYdLf3N2FHHiVjajDXrLhFh
Publisher ID: 4XTTMGc59GywZVY3gipX9nJNeWeW9bFN4h8ui61Q9vKvBM97m
Info: hello world
```

For this to be truly great, I'd like to add persistent configuration to `mcclient`, so we can store the credentials in e.g. `~/.mediachain/mcclient/config.json`.  Then we wouldn't need to require the `--deployCredentialsFile` option for every command.  That seems like it belongs in its own PR though.

Closes #92 