### PR TITLE
Change jq install location, ensure directory exists

### DIFF
--- a/scripts/build-jq.js
+++ b/scripts/build-jq.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const BinBuild = require('bin-build')
+const mkdirp = require('mkdirp')
 
 const JQ_INFO = {
   name: 'jq',
@@ -9,7 +10,8 @@ const JQ_INFO = {
 }
 
 const path = require('path')
-const outputPath = path.join(__dirname, '..', 'node_modules', '.bin', 'jq')
+const outputDir = path.join(__dirname, '..', 'bin')
+const outputPath = path.join(outputDir, 'jq')
 
 const fs = require('fs')
 try {
@@ -25,6 +27,7 @@ const build = new BinBuild()
   .cmd(`cp ./jq ${outputPath}`)
 
 console.log('building jq...')
+mkdirp.sync(outputDir)
 build.run((err) => {
   if (err) {
     console.log('err', err)

--- a/src/metadata/jqStream.js
+++ b/src/metadata/jqStream.js
@@ -3,7 +3,7 @@
 const ChildProcessStream = require('duplex-child-process')
 const byline = require('byline')
 const path = require('path')
-const JQ_PATH = path.join(__dirname, '..', '..', 'node_modules', '.bin', 'jq')
+const JQ_PATH = path.join(__dirname, '..', '..', 'bin', 'jq')
 
 class JQTransform extends ChildProcessStream {
   _args: Array<string>


### PR DESCRIPTION
This fixes the install error described in #97, where jq would fail because we were trying to copy to a non-existent directory.  I changed the jq install dir to `<aleph-root>/bin/jq` instead of trying to put it in the `node_modules/.bin`.  I expect vyzo's "I told you so" on my desk Monday morning 😛.  I also tossed a `mkdirp` in before the build step to ensure the directory exists.