### PR TITLE
mcclient support for GC endpoints

### DIFF
--- a/src/client/api/RestClient.js
+++ b/src/client/api/RestClient.js
@@ -210,6 +210,24 @@ class RestClient {
       })
   }
 
+  garbageCollect (): Promise<number> {
+    return this.postRequest('data/gc', '', false)
+      .then(r => r.text())
+      .then(Number.parseInt)
+  }
+
+  compactDatastore (): Promise<boolean> {
+    return this.postRequest('data/compact', '', false)
+      .then(r => r.text())
+      .then(s => s.trim() === 'OK')
+  }
+
+  syncDatastore (): Promise<boolean> {
+    return this.postRequest('data/sync', '', false)
+      .then(r => r.text())
+      .then(s => s.trim() === 'OK')
+  }
+
   listPeers (): Promise<Array<string>> {
     return this.getRequest('dir/list')
       .then(r => r.text())

--- a/src/client/api/RestClient.js
+++ b/src/client/api/RestClient.js
@@ -210,7 +210,7 @@ class RestClient {
       })
   }
 
-  garbageCollect (): Promise<number> {
+  garbageCollectDatastore (): Promise<number> {
     return this.postRequest('data/gc', '', false)
       .then(r => r.text())
       .then(Number.parseInt)

--- a/src/client/api/RestClient.js
+++ b/src/client/api/RestClient.js
@@ -2,6 +2,7 @@
 
 const fetch: (url: string, opts?: Object) => Promise<FetchResponse> = require('node-fetch')
 const ndjson = require('ndjson')
+const byline = require('byline')
 const serialize = require('../../metadata/serialize')
 
 import type { Transform as TransformStream, Duplex as DuplexStream } from 'stream'
@@ -208,6 +209,17 @@ class RestClient {
           return bytes
         }
       })
+  }
+
+  getDatastoreKeys (): Promise<Array<string>> {
+    return this.getRequest('data/keys')
+      .then(r => r.text())
+      .then(s => s.split('\n').filter(line => line.length > 0))
+  }
+
+  getDatastoreKeyStream (): Promise<TransformStream> {
+    return this.getRequest('data/keys')
+      .then(r => byline(r.body))
   }
 
   garbageCollectDatastore (): Promise<number> {

--- a/src/client/cli/commands/data.js
+++ b/src/client/cli/commands/data.js
@@ -1,0 +1,16 @@
+// @flow
+
+const path = require('path')
+
+module.exports = {
+  command: 'data <subcommand>',
+  describe: `Interact with the local node's datastore. Use "data --help" to see subcommands.\n`,
+  builder: (yargs: Function) => {
+    return yargs
+      .commandDir(path.join(__dirname, './data'))
+      .demand(1, 'Missing command argument')
+      .help()
+      .strict()
+  },
+  handler: () => {}
+}

--- a/src/client/cli/commands/data/compact.js
+++ b/src/client/cli/commands/data/compact.js
@@ -1,0 +1,16 @@
+// @flow
+
+import type {RestClient} from '../../../api'
+const {subcommand} = require('../../util')
+
+module.exports = {
+  command: 'compact',
+  description: 'Compact the datastore to optimize disk usage.\n',
+  handler: subcommand((opts: {client: RestClient}) => {
+    const {client} = opts
+    return client.compactDatastore()
+      .then(() => {
+        console.log('Compaction successful')
+      })
+  })
+}

--- a/src/client/cli/commands/data/gc.js
+++ b/src/client/cli/commands/data/gc.js
@@ -1,0 +1,16 @@
+// @flow
+
+import type {RestClient} from '../../../api'
+const {subcommand, pluralizeCount} = require('../../util')
+
+module.exports = {
+  command: 'gc',
+  description: 'Trigger garbage collection to remove orphan data objects that are not referenced by any statement.\n',
+  handler: subcommand((opts: {client: RestClient}) => {
+    const {client} = opts
+    return client.garbageCollectDatastore()
+      .then(count => {
+        console.log(`Garbage collected ${pluralizeCount(count, 'object')}`)
+      })
+  })
+}

--- a/src/client/cli/commands/data/get.js
+++ b/src/client/cli/commands/data/get.js
@@ -1,0 +1,38 @@
+// @flow
+
+const RestClient = require('../../../api/RestClient')
+const { printJSON, subcommand } = require('../../util')
+
+module.exports = {
+  command: 'get <objectId>',
+  description: 'Request the object with `objectId` from the local node and print to the console.\n',
+  builder: {
+    color: {
+      type: 'boolean',
+      description: 'Explicitly enable (or disable, with --no-color) colorized output.\n',
+      default: null,
+      defaultDescription: 'Print in color if stdout is a tty, and monochrome if piped or pretty-printing is disabled.'
+    },
+    pretty: {
+      type: 'boolean',
+      description: 'Pretty print the output.\n',
+      default: true,
+      defaultDescription: 'True.  Use --no-pretty for compact output.'
+    }
+  },
+
+  handler: subcommand((opts: {client: RestClient, objectId: string, color: ?boolean, pretty: boolean}) => {
+    const {client, objectId, color, pretty} = opts
+
+    return client.getData(objectId)
+      .then(
+        obj => {
+          if (obj instanceof Buffer) {
+            console.log(obj.toString('base64'))
+          } else {
+            printJSON(obj, {color, pretty})
+          }
+        }
+      )
+  })
+}

--- a/src/client/cli/commands/data/keys.js
+++ b/src/client/cli/commands/data/keys.js
@@ -1,0 +1,18 @@
+// @flow
+
+import type {RestClient} from '../../../api'
+const {subcommand} = require('../../util')
+
+module.exports = {
+  command: 'keys',
+  description: 'Print the keys for all objects in the datastore.\n',
+  handler: subcommand((opts: {client: RestClient}) => {
+    const {client} = opts
+    return client.getDatastoreKeyStream()
+      .then(stream => new Promise((resolve, reject) => {
+        stream.on('data', data => { console.log(data.toString()) })
+        stream.on('error', reject)
+        stream.on('end', () => resolve())
+      }))
+  })
+}

--- a/src/client/cli/commands/data/put.js
+++ b/src/client/cli/commands/data/put.js
@@ -1,0 +1,62 @@
+// @flow
+
+const fs = require('fs')
+const ndjson = require('ndjson')
+const RestClient = require('../../../api/RestClient')
+const { subcommand } = require('../../util')
+import type { Readable } from 'stream'
+
+const BATCH_SIZE = 1000
+
+module.exports = {
+  command: 'put [filename]',
+  description: 'Read newline-delimited JSON data from `filename` or stdin and store in the remote node as IPLD.\n',
+  builder: {
+    batchSize: { default: BATCH_SIZE }
+  },
+
+  handler: subcommand((opts: {client: RestClient, batchSize: number, filename: ?string}) => {
+    const {client, batchSize, filename} = opts
+    const streamName = filename || 'standard input'
+
+    let items: Array<Object> = []
+    let promises: Array<Promise<*>> = []
+
+    let inputStream: Readable
+    if (filename) {
+      inputStream = fs.createReadStream(filename)
+    } else {
+      inputStream = process.stdin
+    }
+
+    return new Promise((resolve, reject) => {
+      inputStream.pipe(ndjson.parse())
+        .on('data', obj => {
+          items.push(obj)
+          if (items.length >= batchSize) {
+            promises.push(putItems(client, items))
+            items = []
+          }
+        })
+        .on('end', () => {
+          if (items.length > 0) {
+            promises.push(putItems(client, items))
+          }
+          Promise.all(promises)
+            .then(() => resolve())
+        })
+        .on('error', err => {
+          err = new Error(`Error reading from ${streamName}: ${err.message}`)
+          reject(err)
+        })
+    })
+  })
+}
+
+function putItems (client: RestClient, items: Array<Object>): Promise<*> {
+  return client.putData(...items).then(
+    hashes => {
+      hashes.forEach(h => console.log(h))
+    }
+  )
+}

--- a/src/client/cli/commands/data/sync.js
+++ b/src/client/cli/commands/data/sync.js
@@ -1,0 +1,16 @@
+// @flow
+
+import type {RestClient} from '../../../api'
+const {subcommand} = require('../../util')
+
+module.exports = {
+  command: 'sync',
+  description: 'Flushes the datastore.  Useful for immediately reclaiming space after garbage collection\n',
+  handler: subcommand((opts: {client: RestClient}) => {
+    const {client} = opts
+    return client.syncDatastore()
+      .then(count => {
+        console.log(`Sync successful`)
+      })
+  })
+}

--- a/src/client/cli/commands/getData.js
+++ b/src/client/cli/commands/getData.js
@@ -1,38 +1,8 @@
 // @flow
 
-const RestClient = require('../../api/RestClient')
-const { printJSON, subcommand } = require('../util')
+const cmd = require('./data/get')
 
-module.exports = {
+module.exports = Object.assign({}, cmd, {
   command: 'getData <objectId>',
-  description: 'Request the object with `objectId` from the local node and print to the console.\n',
-  builder: {
-    color: {
-      type: 'boolean',
-      description: 'Explicitly enable (or disable, with --no-color) colorized output.\n',
-      default: null,
-      defaultDescription: 'Print in color if stdout is a tty, and monochrome if piped or pretty-printing is disabled.'
-    },
-    pretty: {
-      type: 'boolean',
-      description: 'Pretty print the output.\n',
-      default: true,
-      defaultDescription: 'True.  Use --no-pretty for compact output.'
-    }
-  },
-
-  handler: subcommand((opts: {client: RestClient, objectId: string, color: ?boolean, pretty: boolean}) => {
-    const {client, objectId, color, pretty} = opts
-
-    return client.getData(objectId)
-      .then(
-        obj => {
-          if (obj instanceof Buffer) {
-            console.log(obj.toString('base64'))
-          } else {
-            printJSON(obj, {color, pretty})
-          }
-        }
-      )
-  })
-}
+  description: `${cmd.description.trim()} (alias for 'data get')\n`
+})

--- a/src/client/cli/commands/putData.js
+++ b/src/client/cli/commands/putData.js
@@ -1,62 +1,8 @@
 // @flow
 
-const fs = require('fs')
-const ndjson = require('ndjson')
-const RestClient = require('../../api/RestClient')
-const { subcommand } = require('../util')
-import type { Readable } from 'stream'
+const cmd = require('./data/put')
 
-const BATCH_SIZE = 1000
-
-module.exports = {
+module.exports = Object.assign({}, cmd, {
   command: 'putData [filename]',
-  description: 'Read newline-delimited JSON data from `filename` or stdin and store in the remote node as IPLD.\n',
-  builder: {
-    batchSize: { default: BATCH_SIZE }
-  },
-
-  handler: subcommand((opts: {client: RestClient, batchSize: number, filename: ?string}) => {
-    const {client, batchSize, filename} = opts
-    const streamName = filename || 'standard input'
-
-    let items: Array<Object> = []
-    let promises: Array<Promise<*>> = []
-
-    let inputStream: Readable
-    if (filename) {
-      inputStream = fs.createReadStream(filename)
-    } else {
-      inputStream = process.stdin
-    }
-
-    return new Promise((resolve, reject) => {
-      inputStream.pipe(ndjson.parse())
-        .on('data', obj => {
-          items.push(obj)
-          if (items.length >= batchSize) {
-            promises.push(putItems(client, items))
-            items = []
-          }
-        })
-        .on('end', () => {
-          if (items.length > 0) {
-            promises.push(putItems(client, items))
-          }
-          Promise.all(promises)
-            .then(() => resolve())
-        })
-        .on('error', err => {
-          err = new Error(`Error reading from ${streamName}: ${err.message}`)
-          reject(err)
-        })
-    })
-  })
-}
-
-function putItems (client: RestClient, items: Array<Object>): Promise<*> {
-  return client.putData(...items).then(
-    hashes => {
-      hashes.forEach(h => console.log(h))
-    }
-  )
-}
+  description: `${cmd.description.trim()} (alias for 'data put')\n`
+})


### PR DESCRIPTION
This adds some new commands to support the new endpoints added in https://github.com/mediachain/concat/pull/88

- `mcclient data gc`
- `mcclient data compact`
- `mcclient data sync`
- `mcclient data keys`

It also moves `getData` and `putData` to `mcclient data get` and `mcclient data put`, but keeps the old commands around as aliases.  Now that we have a bunch of datastore commands it seemed appropriate to group them.

@vyzo let me know if I'm missing anything.  I remember you saying something about making sync a flag on the gc command?  But my memory is fuzzy enough that I figured I'd wait till tomorrow and you can set me straight.