### PR TITLE
Add lookupPeer command & net/lookup api support

### DIFF
--- a/src/client/api/RestClient.js
+++ b/src/client/api/RestClient.js
@@ -313,6 +313,13 @@ class RestClient {
       .then(addrs => addrs.filter(s => s.length > 0))
   }
 
+  netLookup (peerId: string): Promise<Array<string>> {
+    return this.getRequest(`net/lookup/${peerId}`)
+      .then(r => r.text())
+      .then(s => s.split('\n'))
+      .then(a => a.filter(s => s.length > 0))
+  }
+
   shutdown (): Promise<boolean> {
     return this.postRequest('shutdown', '', false)
       .then(() => true)

--- a/src/client/cli/commands/lookupPeer.js
+++ b/src/client/cli/commands/lookupPeer.js
@@ -1,0 +1,22 @@
+// @flow
+
+const RestClient = require('../../api/RestClient')
+const { subcommand } = require('../util')
+
+module.exports = {
+  command: 'lookupPeer <peerId>',
+  describe: 'Lookup a remote peer, identified by `peerId`. ' +
+  'Will first try the directory if one is configured, otherwise will fallback to DHT lookup.\n',
+  handler: subcommand((opts: {peerId: string, client: RestClient}) => {
+    const {peerId, client} = opts
+    console.log('Looking up peer: ', peerId)
+
+    return client.netLookup(peerId)
+      .then(
+        addrs => {
+          addrs.forEach(a => { console.log(a) })
+        },
+        err => { throw new Error(`Error during peer lookup: ${err.message}`) }
+      )
+  })
+}

--- a/src/client/cli/commands/ping.js
+++ b/src/client/cli/commands/ping.js
@@ -6,7 +6,7 @@ const { subcommand } = require('../util')
 module.exports = {
   command: 'ping <peerId>',
   describe: 'Ping a remote peer, identified by `peerId`. ' +
-  'The local node must be configured to use a directory server.\n',
+  'Will attempt to lookup the peer with a configured directory server or DHT.\n',
   handler: subcommand((opts: {peerId: string, client: RestClient}) => {
     const {peerId, client} = opts
     console.log('Pinging peer: ', peerId)


### PR DESCRIPTION
This adds the `/net/lookup/:peerId` endpoint to `RestClient` and a `lookupPeer` cli command that uses it.

Depends on https://github.com/mediachain/concat/pull/90