### PR TITLE
Try to fetch precompiled jq, fall back to building

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build-jq": "node scripts/build-jq.js",
     "postinstall": "npm run build-jq",
     "test": "mocha --compilers js:babel-register ./test",
-    "build": "mkdir -p ./lib && babel --copy-files src -d lib",
+    "build": "mkdirp ./lib && babel --copy-files src -d lib",
     "check": "standard && flow",
     "cli": "npm run build >/dev/null && node ./lib/client/cli/index.js",
     "prepublish": "npm run build"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "bin-build": "^2.2.0",
     "byline": "^5.0.0",
     "cbor": "3.0.0",
+    "digest-stream": "^1.0.1",
     "duplex-child-process": "0.0.5",
     "libp2p-crypto": "0.7.3",
     "libp2p-secio": "0.6.3",

--- a/scripts/build-jq.js
+++ b/scripts/build-jq.js
@@ -7,24 +7,25 @@ const BinBuild = require('bin-build')
 const mkdirp = require('mkdirp')
 const { get } = require('lodash')
 const fetch = require('node-fetch')
+const digestStream = require('digest-stream')
 
 const JQ_INFO = {
   name: 'jq',
-  url: 'https://github.com/stedolan/jq/releases/download/',
+  url: 'https://github.com/stedolan/jq/releases/download',
   version: 'jq-1.5'
 }
 
-const BINARY_NAMES = {
+const BINARY_INFO = {
   linux: {
-    x86: 'jq-linux32',
-    x64: 'jq-linux64'
+    x86: {name: 'jq-linux32', sha256: 'ab440affb9e3f546cf0d794c0058543eeac920b0cd5dff660a2948b970beb632'},
+    x64: {name: 'jq-linux64', sha256: 'c6b3a7d7d3e7b70c6f51b706a3b90bd01833846c54d32ca32f0027f00226ff6d'}
   },
   darwin: {
-    x64: 'jq-osx-amd64'
+    x64: {name: 'jq-osx-amd64', sha256: '386e92c982a56fe4851468d7a931dfca29560cee306a0e66c6a1bd4065d3dac5'}
   },
   win32: {
-    x86: 'jq-win32.exe',
-    x64: 'jq-win64.exe'
+    x86: {name: 'jq-win32.exe', sha256: '1860c77bc2816b74f91705b84c7fa0dad3a062b355f021aa8c8e427e388e23fc'},
+    x64: {name: 'jq-win64.exe', sha256: 'ebecd840ba47efbf66822868178cc721a151060937f7ac406e3d31bd015bde94'}
   }
 }
 
@@ -46,25 +47,43 @@ const build = new BinBuild()
 function downloadBinary (destinationPath) {
   const platform = os.platform()
   const arch = os.arch()
-  const binName = get(BINARY_NAMES, [platform, arch])
-  if (binName == null) {
+  const binInfo = get(BINARY_INFO, [platform, arch])
+  if (binInfo == null) {
     throw new Error(`No jq binary for ${platform}/${arch}`)
   }
 
-  const binUrl = [JQ_INFO.url, JQ_INFO.version, binName].join('/')
-  console.log('Downloading jq binary from ', binUrl)
+  const {name, sha256} = binInfo
+  const binUrl = [JQ_INFO.url, JQ_INFO.version, name].join('/')
+  console.log(`Downloading jq binary from ${binUrl}`)
   return fetch(binUrl)
     .then(response => new Promise((resolve, reject) => {
+      const hashStream = digestStream('sha256', 'hex', (digest) => {
+        if (digest !== sha256) {
+          return new Error(`Expected ${name} to have sha256 checksum of ${sha256}, actual: ${digest}`)
+        }
+      })
       const output = fs.createWriteStream(destinationPath)
       response.body.on('error', reject)
+      hashStream.on('error', reject)
       output.on('error', reject)
       output.on('close', resolve)
-      response.body.pipe(output)
+      response.body
+        .pipe(hashStream)
+        .pipe(output)
     }))
     .then(() => {
       if (platform !== 'win32') {
         fs.chmodSync(destinationPath, '755')
       }
+    })
+    .catch(err => {
+      // delete output file on download error
+      try {
+        fs.unlinkSync(destinationPath)
+      } catch (e) {
+        // ignore deletion errors, just re-throw the underlying error
+      }
+      throw err
     })
 }
 
@@ -72,12 +91,12 @@ mkdirp.sync(outputDir)
 
 downloadBinary(outputPath)
   .catch(err => {
-    console.log('Error downloading jq binary: ', err.message)
+    console.log(`Error downloading jq binary: ${err.message}`)
     console.log('building jq...')
 
     build.run((err) => {
       if (err) {
-        console.log('err', err)
+        console.log('Error building jq: ', err)
         process.exit(1)
       } else {
         console.log(`jq compiled to ${outputPath}`)

--- a/scripts/build-jq.js
+++ b/scripts/build-jq.js
@@ -1,7 +1,12 @@
 #!/usr/bin/env node
 
+const os = require('os')
+const fs = require('fs')
+const path = require('path')
 const BinBuild = require('bin-build')
 const mkdirp = require('mkdirp')
+const { get } = require('lodash')
+const fetch = require('node-fetch')
 
 const JQ_INFO = {
   name: 'jq',
@@ -9,11 +14,23 @@ const JQ_INFO = {
   version: 'jq-1.5'
 }
 
-const path = require('path')
+const BINARY_NAMES = {
+  linux: {
+    x86: 'jq-linux32',
+    x64: 'jq-linux64'
+  },
+  darwin: {
+    x64: 'jq-osx-amd64'
+  },
+  win32: {
+    x86: 'jq-win32.exe',
+    x64: 'jq-win64.exe'
+  }
+}
+
 const outputDir = path.join(__dirname, '..', 'bin')
 const outputPath = path.join(outputDir, 'jq')
 
-const fs = require('fs')
 try {
   fs.accessSync(outputPath, fs.F_OK)
   // already exists
@@ -26,13 +43,45 @@ const build = new BinBuild()
   .cmd('make')
   .cmd(`cp ./jq ${outputPath}`)
 
-console.log('building jq...')
-mkdirp.sync(outputDir)
-build.run((err) => {
-  if (err) {
-    console.log('err', err)
-    process.exit(1)
-  } else {
-    console.log(`jq compiled to ${outputPath}`)
+function downloadBinary (destinationPath) {
+  const platform = os.platform()
+  const arch = os.arch()
+  const binName = get(BINARY_NAMES, [platform, arch])
+  if (binName == null) {
+    throw new Error(`No jq binary for ${platform}/${arch}`)
   }
-})
+
+  const binUrl = [JQ_INFO.url, JQ_INFO.version, binName].join('/')
+  console.log('Downloading jq binary from ', binUrl)
+  return fetch(binUrl)
+    .then(response => new Promise((resolve, reject) => {
+      const output = fs.createWriteStream(destinationPath)
+      response.body.on('error', reject)
+      output.on('error', reject)
+      output.on('close', resolve)
+      response.body.pipe(output)
+    }))
+    .then(() => {
+      if (platform !== 'win32') {
+        fs.chmodSync(destinationPath, '755')
+      }
+    })
+}
+
+mkdirp.sync(outputDir)
+
+downloadBinary(outputPath)
+  .catch(err => {
+    console.log('Error downloading jq binary: ', err.message)
+    console.log('building jq...')
+
+    build.run((err) => {
+      if (err) {
+        console.log('err', err)
+        process.exit(1)
+      } else {
+        console.log(`jq compiled to ${outputPath}`)
+      }
+    })
+  })
+


### PR DESCRIPTION
This adds a step to `build-jq.js` that first tries to download the precompiled binary for jq for the platform it's running on, falling back to building it if there isn't one, or if the download fails.

Makes the installation speedier, and also makes it possible to install aleph on "real" windows, now that node-webcrypto-ossl is an optional dependency. (although you still need a C++ compiler setup for the sha3 module).

TODO:

- [x] add checksum verification to the downloaded file; don't assume it's correct