### PR TITLE
Update concat-dependencies Dockerfile

### DIFF
--- a/integration-test/concat-dependencies/Dockerfile
+++ b/integration-test/concat-dependencies/Dockerfile
@@ -1,22 +1,14 @@
-FROM golang:1.7.1
+FROM golang:1.7.3
 
 ARG concat_ref=master
 
-# install gx and gx-go
-RUN go get github.com/whyrusleeping/gx
-RUN go get github.com/whyrusleeping/gx-go
-
-# Fetch package.json so we can gx install
+# Fetch package.json so the setup script can find gx dependencies
 WORKDIR /go/src/github.com/mediachain/concat
-RUN curl -O https://raw.githubusercontent.com/mediachain/concat/${concat_ref}/package.json
+RUN curl -O -L https://raw.githubusercontent.com/mediachain/concat/${concat_ref}/package.json
 
-# install gx dependencies
-RUN gx install --global
-
-# go get some of the bigger dependencies
-RUN go get github.com/gorilla/mux
-RUN go get github.com/mattn/go-sqlite3 
-RUN go get -tags=embed github.com/tecbot/gorocksdb
+# Fetch the setup script and run it
+RUN curl -O -L https://raw.githubusercontent.com/mediachain/concat/${concat_ref}/setup.sh
+RUN bash ./setup.sh
 
 # remove the mediachain dir from the go source root, so we can clone into it in a child image
 RUN rm -rf /go/src/github.com/mediachain/concat


### PR DESCRIPTION
This updates the concat-dependencies Dockerfile:

- update go base image 1.7.3 from 1.7.1
- use standard setup.sh script

Since this is based on the latest master, it gets the most recent gx dependencies.  It's already pushed to Docker hub, and I removed the Travis environment variable that skips the integration tests, so this seems to have fixed up our CI mess.