### PR TITLE
Fix for records not actually being validated during publish

### DIFF
--- a/src/client/cli/commands/publish.js
+++ b/src/client/cli/commands/publish.js
@@ -93,7 +93,7 @@ module.exports = {
         })
         .then((schema) => {
           try {
-            schema = validateSelfDescribingSchema(schema)
+            return validateSelfDescribingSchema(schema)
           } catch (err) {
             throw new Error(
               `Schema with object id ${schemaReference} is not a valid self-describing schema: ${err.message}`
@@ -160,13 +160,13 @@ function publishStream (opts: {
           wki = parsed.wki
           obj = parsed.obj
         } catch (err) {
-          throw new Error(`Error parsing jq output: ${err}\njq output: ${jsonString}`)
+          return reject(new Error(`Error parsing jq output: ${err}\njq output: ${jsonString}`))
         }
 
         if (schema != null && !skipSchemaValidation) {
           const result = validate(schema, obj)
           if (!result.success) {
-            throw new Error(`Record failed validation: ${result.error.message}. Failed object: ${JSON.stringify(obj, null, 2)}`)
+            return reject(new Error(`Record failed validation: ${result.error.message}. Failed object: ${JSON.stringify(obj, null, 2)}`))
           }
         }
 

--- a/src/client/cli/commands/publish.js
+++ b/src/client/cli/commands/publish.js
@@ -189,9 +189,9 @@ function publishStream (opts: {
           if (isSelfDescribingRecord(obj)) {
             const ref = objectPath.get(obj, 'schema', '/')
             if (ref !== schemaReference) {
-              throw new Error(
+              return reject(new Error(
                 `Record contains reference to a different schema (${ref}) than the one specified ${schemaReference}`
-              )
+              ))
             }
           } else {
             obj = {


### PR DESCRIPTION
While working on some docs for publishing with json schema, I noticed that we weren't actually throwing validation errors for invalid records 😞 

This was caused by forgetting to actually return the schema object.  Anyway, this fixes that, and also  fixes the error handling so that errors call `reject` instead of throwing, so we just print the error message instead of the full stack trace.
