### PR TITLE
Add net/conn and net/addr/:peerId support to mcclient

### DIFF
--- a/src/client/api/RestClient.js
+++ b/src/client/api/RestClient.js
@@ -277,8 +277,18 @@ class RestClient {
       .then(parseBoolResponse)
   }
 
-  getNetAddresses (): Promise<Array<string>> {
+  getNetAddresses (peerId: ?string = null): Promise<Array<string>> {
+    if (peerId != null) {
+      return this.getRequest(`net/addr/${peerId}`)
+        .then(parseStringArrayResponse)
+    }
+
     return this.getRequest('net/addr')
+      .then(parseStringArrayResponse)
+  }
+
+  getNetConnections (): Promise<Array<string>> {
+    return this.getRequest('net/conns')
       .then(parseStringArrayResponse)
   }
 

--- a/src/client/cli/commands/netAddr.js
+++ b/src/client/cli/commands/netAddr.js
@@ -4,18 +4,23 @@ const RestClient = require('../../api/RestClient')
 const { subcommand } = require('../util')
 
 module.exports = {
-  command: 'netAddr',
-  describe: `Print the local node's network addresses in multiaddr format.\n`,
-  handler: subcommand((opts: {client: RestClient}) => {
-    const {client} = opts
+  command: 'netAddr [peerId]',
+  describe: `Print the local node's network addresses in multiaddr format. ` +
+    `If 'peerId' is given, prints the locally known addresses for that peer (useful for debugging).\n`,
+  handler: subcommand((opts: {client: RestClient, peerId?: string}) => {
+    const {client, peerId} = opts
 
-    return client.getNetAddresses()
+    return client.getNetAddresses(peerId)
       .then(
         addresses => {
           if (addresses.length < 1) {
-            console.warn(
-              'Local node does not have an address. Make sure status is set to "online" or "public"'
-            )
+            if (peerId != null) {
+              console.warn(`No known addresses for peer ${peerId}`)
+            } else {
+              console.warn(
+                'Local node does not have an address. Make sure status is set to "online" or "public"'
+              )
+            }
           } else {
             addresses.forEach(addr => {
               console.log(addr)

--- a/src/client/cli/commands/netConnections.js
+++ b/src/client/cli/commands/netConnections.js
@@ -1,0 +1,29 @@
+// @flow
+
+const RestClient = require('../../api/RestClient')
+const { subcommand } = require('../util')
+
+module.exports = {
+  command: 'netConnections',
+  describe: `Print a list of all actively connected peers (useful for debugging).\n`,
+  handler: subcommand((opts: {client: RestClient}) => {
+    const {client} = opts
+
+    return client.getNetConnections()
+      .then(
+        addresses => {
+          if (addresses.length < 1) {
+            console.log(
+              'No active network connections.  Is the node online?'
+            )
+          } else {
+            addresses.forEach(addr => {
+              console.log(addr)
+            })
+          }
+        })
+      .catch(
+        err => { throw new Error(`Error retrieving network connection list: ${err.message}`) }
+      )
+  })
+}


### PR DESCRIPTION
Brings mcclient up to date with https://github.com/mediachain/concat/pull/97

Adds the `mcclient netConnections` command to list active connections, and an optional `peerId` argument to `mcclient netAddr` to show known addresses.

Also does a bit of refactoring to the response parsing code in RestClient, since I was getting tired of repeating the same string splitting and number parsing code for each new endpoint.