### PR TITLE
Batch data object fetching for mcclient

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1536,6 +1536,11 @@
       "from": "map-obj@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
     },
+    "map-stream": {
+      "version": "0.0.6",
+      "from": "map-stream@latest",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.6.tgz"
+    },
     "meow": {
       "version": "3.7.0",
       "from": "meow@>=3.3.0 <4.0.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "libp2p-websockets": "0.9.1",
     "lodash": "^4.17.1",
     "mafmt": "^2.1.2",
+    "map-stream": "0.0.6",
     "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
     "multiaddr": "2.1.1",
     "multihashes": "^0.3.0",

--- a/src/client/api/RestClient.js
+++ b/src/client/api/RestClient.js
@@ -3,9 +3,10 @@
 const fetch: (url: string, opts?: Object) => Promise<FetchResponse> = require('node-fetch')
 const ndjson = require('ndjson')
 const byline = require('byline')
+const mapStream = require('map-stream')
 const serialize = require('../../metadata/serialize')
 
-import type { Transform as TransformStream, Duplex as DuplexStream } from 'stream'
+import type { Transform as TransformStream, Duplex as DuplexStream, Readable as ReadableStream } from 'stream'
 import type { StatementMsg, SimpleStatementMsg } from '../../protobuf/types'
 export type NodeStatus = 'online' | 'offline' | 'public'
 
@@ -32,13 +33,7 @@ class NDJsonResponse {
   }
 
   values (): Promise<Array<Object>> {
-    return new Promise((resolve, reject) => {
-      const vals = []
-      const stream = this.stream()
-      stream.on('data', val => { vals.push(val) })
-      stream.on('error', reject)
-      stream.on('finish', () => { resolve(vals) })
-    })
+    return collectStream(this.stream())
   }
 }
 
@@ -181,14 +176,28 @@ class RestClient {
   getData (objectId: string): Promise<Object | Buffer> {
     return this.getRequest(`data/get/${objectId}`)
       .then(r => r.json())
-      .then(o => Buffer.from(o.data, 'base64'))
-      .then(bytes => {
-        try {
-          return serialize.decode(bytes)
-        } catch (err) {
-          return bytes
-        }
+      .then(parseDataObjectResponse)
+  }
+
+  batchGetDataStream (objectIds: Array<string>): Promise<TransformStream> {
+    return this.postRequest('data/get', objectIds.join('\n'), false)
+      .then(r => new NDJsonResponse(r).stream())
+      .then((stream: DuplexStream) => {
+        const outputStream = mapStream((obj: Object, callback: Function) => {
+          try {
+            callback(null, parseDataObjectResponse(obj))
+          } catch (err) {
+            callback(err)
+          }
+        })
+        stream.pipe(outputStream)
+        return outputStream
       })
+  }
+
+  batchGetData (objectIds: Array<string>): Promise<Array<Object | Buffer>> {
+    return this.batchGetDataStream(objectIds)
+      .then(collectStream)
   }
 
   getDatastoreKeys (): Promise<Array<string>> {
@@ -354,6 +363,27 @@ function parseMergeResponse (response: FetchResponse): Promise<{objectCount: num
         objectCount
       }
     })
+}
+
+function parseDataObjectResponse (obj: Object): Buffer | Object {
+  if (obj.error !== undefined) {
+    throw new Error(obj.error)
+  }
+  const data = Buffer.from(obj.data, 'base64')
+  try {
+    return serialize.decode(data)
+  } catch (err) {
+    return data
+  }
+}
+
+function collectStream<T> (stream: ReadableStream): Promise<Array<T>> {
+  return new Promise((resolve, reject) => {
+    const vals = []
+    stream.on('data', val => { vals.push(val) })
+    stream.on('error', reject)
+    stream.on('end', () => { resolve(vals) })
+  })
 }
 
 module.exports = RestClient

--- a/src/client/cli/commands/data/get.js
+++ b/src/client/cli/commands/data/get.js
@@ -7,7 +7,8 @@ import type { Readable as ReadableStream } from 'stream'
 module.exports = {
   command: 'get <objectIds..>',
   description: 'Request one or more `objectIds` from the local node and print to the console.' +
-    'If multiple ids are given, results will be returned as a JSON map, with objectIds as keys.\n',
+    'If multiple ids are given and pretty-printing is enabled, results will be returned as a JSON map, ' +
+    'with `objectIds` as keys.\n',
   builder: {
     color: {
       type: 'boolean',
@@ -20,55 +21,81 @@ module.exports = {
       description: 'Pretty print the output.\n',
       default: true,
       defaultDescription: 'True.  Use --no-pretty for compact output.'
+    },
+    batch: {
+      type: 'boolean',
+      description: 'Force "batch-mode", even if only one key is given.  Disables color and pretty-printing.\n',
+      default: false
     }
   },
 
-  handler: subcommand((opts: {client: RestClient, objectIds: Array<string>, color: ?boolean, pretty: boolean}) => {
-    const {client, objectIds, color, pretty} = opts
+  handler: subcommand((opts: {client: RestClient, objectIds: Array<string>, color: ?boolean, pretty: boolean, batch: boolean}) => {
+    const {client, objectIds, batch} = opts
+    let {color, pretty} = opts
+    if (batch) {
+      color = false
+      pretty = false
+    }
 
-    if (objectIds.length === 1) {
+    if (!batch && objectIds.length === 1) {
       return client.getData(objectIds[0])
         .then(objectFormatter(color, pretty))
         .then(output => process.stdout.write(output))
     }
 
     return client.batchGetDataStream(objectIds)
-      .then(stream => printStream(stream, objectIds, color, pretty))
+      .then(stream => {
+        if (pretty) {
+          return printStreamPretty(stream, objectIds, color)
+        } else {
+          return printStreamCompact(stream)
+        }
+      })
   })
 }
 
-function printStream (stream: ReadableStream, objectIds: Array<string>, color: ?boolean, pretty: boolean): Promise<void> {
-  const formatObject = objectFormatter(color, pretty)
-  const {stdout} = process
-  stdout.write('{')
-  if (pretty) {
-    stdout.write('\n')
-  }
-
+function printStreamCompact (stream: ReadableStream): Promise<void> {
   return new Promise((resolve, reject) => {
-    const leftPad = pretty ? '  ' : ''
+    const formatObject = objectFormatter(false, false)
+    const {stdout} = process
+    stream.on('data', obj => {
+      stdout.write(formatObject(obj))
+    })
+    stream.on('end', resolve)
+    stream.on('error', reject)
+  })
+}
+
+function printStreamPretty (stream: ReadableStream, objectIds: Array<string>, color: ?boolean, wrap: boolean = true): Promise<void> {
+  const formatObject = objectFormatter(color, true)
+  const {stdout} = process
+  const padding = wrap ? 2 : 0
+  if (wrap) {
+    stdout.write('{\n')
+  }
+  return new Promise((resolve, reject) => {
     stream.on('data', result => {
       const key = objectIds.pop()
       const keyString = formatObject(key).trim()
       const formatted = formatObject(result).trim()
-        .split('\n')
-        .map((s, i) => (i === 0) ? s : leftPad + s)
-        .join('\n')
+      const output = indent(`${keyString}: ${formatted}`, padding)
+      stdout.write(output)
 
-      stdout.write(`${leftPad}${keyString}: ${formatted}`)
-      if (objectIds.length > 0) {
+      if (wrap && objectIds.length > 0) {
         stdout.write(',')
       }
-      if (pretty) {
-        stdout.write('\n')
-      }
+      stdout.write('\n')
     })
     stream.on('error', (err) => {
-      stdout.write(`}\n`)
+      if (wrap) {
+        stdout.write(`}\n`)
+      }
       reject(err)
     })
     stream.on('end', () => {
-      stdout.write(`}\n`)
+      if (wrap) {
+        stdout.write(`}\n`)
+      }
       resolve()
     })
   })
@@ -80,4 +107,9 @@ const objectFormatter = (color: ?boolean, pretty: boolean) => (obj: ?mixed): str
   }
 
   return formatJSON(obj, {color, pretty})
+}
+
+function indent (s: string, spaces: number = 2): string {
+  const padding = new Array(spaces).fill(' ').join('')
+  return s.split('\n').map(line => padding + line).join('\n')
 }

--- a/src/client/cli/commands/data/get.js
+++ b/src/client/cli/commands/data/get.js
@@ -1,11 +1,13 @@
 // @flow
 
 const RestClient = require('../../../api/RestClient')
-const { printJSON, subcommand } = require('../../util')
+const { formatJSON, subcommand } = require('../../util')
+import type { Readable as ReadableStream } from 'stream'
 
 module.exports = {
   command: 'get <objectIds..>',
-  description: 'Request one or more `objectIds` from the local node and print to the console.\n',
+  description: 'Request one or more `objectIds` from the local node and print to the console.' +
+    'If multiple ids are given, results will be returned as a JSON map, with objectIds as keys.\n',
   builder: {
     color: {
       type: 'boolean',
@@ -23,22 +25,59 @@ module.exports = {
 
   handler: subcommand((opts: {client: RestClient, objectIds: Array<string>, color: ?boolean, pretty: boolean}) => {
     const {client, objectIds, color, pretty} = opts
-    const printObject = objectPrinter(color, pretty)
+
+    if (objectIds.length === 1) {
+      return client.getData(objectIds[0])
+        .then(objectFormatter(color, pretty))
+        .then(output => process.stdout.write(output))
+    }
+
     return client.batchGetDataStream(objectIds)
-      .then(
-        stream => new Promise((resolve, reject) => {
-          stream.on('data', printObject)
-          stream.on('error', reject)
-          stream.on('end', resolve)
-        })
-      )
+      .then(stream => printStream(stream, objectIds, color, pretty))
   })
 }
 
-const objectPrinter = (color: ?boolean, pretty: boolean) => (obj: Buffer | Object) => {
-  if (obj instanceof Buffer) {
-    console.log(obj.toString('base64'))
-  } else {
-    printJSON(obj, {color, pretty})
+function printStream (stream: ReadableStream, objectIds: Array<string>, color: ?boolean, pretty: boolean): Promise<void> {
+  const formatObject = objectFormatter(color, pretty)
+  const {stdout} = process
+  stdout.write('{')
+  if (pretty) {
+    stdout.write('\n')
   }
+
+  return new Promise((resolve, reject) => {
+    const leftPad = pretty ? '  ' : ''
+    stream.on('data', result => {
+      const key = objectIds.pop()
+      const keyString = formatObject(key).trim()
+      const formatted = formatObject(result).trim()
+        .split('\n')
+        .map((s, i) => (i === 0) ? s : leftPad + s)
+        .join('\n')
+
+      stdout.write(`${leftPad}${keyString}: ${formatted}`)
+      if (objectIds.length > 0) {
+        stdout.write(',')
+      }
+      if (pretty) {
+        stdout.write('\n')
+      }
+    })
+    stream.on('error', (err) => {
+      stdout.write(`}\n`)
+      reject(err)
+    })
+    stream.on('end', () => {
+      stdout.write(`}\n`)
+      resolve()
+    })
+  })
+}
+
+const objectFormatter = (color: ?boolean, pretty: boolean) => (obj: ?mixed): string => {
+  if (obj instanceof Buffer) {
+    obj = obj.toString('base64')
+  }
+
+  return formatJSON(obj, {color, pretty})
 }

--- a/src/client/cli/commands/getData.js
+++ b/src/client/cli/commands/getData.js
@@ -3,6 +3,6 @@
 const cmd = require('./data/get')
 
 module.exports = Object.assign({}, cmd, {
-  command: 'getData <objectId>',
+  command: 'getData <objectIds..>',
   description: `${cmd.description.trim()} (alias for 'data get')\n`
 })

--- a/src/client/cli/util.js
+++ b/src/client/cli/util.js
@@ -8,8 +8,8 @@ const childProcess = require('child_process')
 const sshTunnel = require('tunnel-ssh')
 const { RestClient } = require('../api')
 
-function printJSON (obj: Object,
-                    options: {color?: ?boolean, pretty?: boolean} = {}) {
+function formatJSON (obj: ?mixed,
+                    options: {color?: ?boolean, pretty?: boolean} = {}): string {
   const compactOutput = options.pretty === false
 
   let useColor = false
@@ -20,8 +20,7 @@ function printJSON (obj: Object,
 
   if (!useColor && compactOutput) {
     // skip jq if we don't want color or pretty printing
-    console.log(JSON.stringify(obj))
-    return
+    return JSON.stringify(obj) + '\n'
   }
 
   const jqOpts = [(useColor ? '-C' : '-M'), '-a', '.']
@@ -29,8 +28,12 @@ function printJSON (obj: Object,
     jqOpts.unshift('-c')
   }
 
-  const output = childProcess.execFileSync(JQ_PATH, jqOpts, {input: JSON.stringify(obj), encoding: 'utf-8'})
-  process.stdout.write(output)
+  return childProcess.execFileSync(JQ_PATH, jqOpts, {input: JSON.stringify(obj), encoding: 'utf-8'}).toString()
+}
+
+function printJSON (obj: ?mixed,
+                    options: {color?: ?boolean, pretty?: boolean} = {}) {
+  process.stdout.write(formatJSON(obj, options))
 }
 
 function pluralizeCount (count: number, word: string): string {
@@ -137,6 +140,7 @@ function subcommand<T: SubcommandGlobalOptions> (handler: (argv: T) => Promise<*
 }
 
 module.exports = {
+  formatJSON,
   printJSON,
   pluralizeCount,
   isB58Multihash,


### PR DESCRIPTION
Adds support for the batch get support added in https://github.com/mediachain/concat/pull/100

The `mcclient data get` command now accepts multiple keys and will fetch them with the batch interface.

Right now it prints the returned objects directly to the console one after another; I'm torn on whether we should wrap them in an array literal first, so that the entire output would be valid JSON.