### PR TITLE
mcclient support for namespace listings

### DIFF
--- a/src/client/api/RestClient.js
+++ b/src/client/api/RestClient.js
@@ -237,9 +237,9 @@ class RestClient {
     let path = 'dir/list'
     if (namespace != null) {
       path = path + '/' + namespace
-    }
-    if (includeSelf) {
-      path = path + '/all'
+      if (includeSelf) {
+        path = path + '/all'
+      }
     }
     return this.getRequest(path)
       .then(parseStringArrayResponse)

--- a/src/client/api/RestClient.js
+++ b/src/client/api/RestClient.js
@@ -233,8 +233,15 @@ class RestClient {
       .then(parseBoolResponse)
   }
 
-  listPeers (): Promise<Array<string>> {
-    return this.getRequest('dir/list')
+  listPeers (namespace?: ?string, includeSelf: boolean = false): Promise<Array<string>> {
+    let path = 'dir/list'
+    if (namespace != null) {
+      path = path + '/' + namespace
+    }
+    if (includeSelf) {
+      path = path + '/all'
+    }
+    return this.getRequest(path)
       .then(parseStringArrayResponse)
   }
 

--- a/src/client/api/RestClient.js
+++ b/src/client/api/RestClient.js
@@ -238,6 +238,11 @@ class RestClient {
       .then(parseStringArrayResponse)
   }
 
+  listNamespaces (): Promise<Array<string>> {
+    return this.getRequest('dir/listns')
+      .then(parseStringArrayResponse)
+  }
+
   getAuthorizations (): Promise<Object> {
     return this.getRequest('auth')
       .then(r => r.json())

--- a/src/client/cli/commands/listNamespaces.js
+++ b/src/client/cli/commands/listNamespaces.js
@@ -10,7 +10,7 @@ module.exports = {
     const {client} = opts
     return client.listNamespaces().then(
       namespaces => {
-        namespaces.forEach(ns => console.log(ns))
+        namespaces.sort().forEach(ns => console.log(ns))
       }
     )
   })

--- a/src/client/cli/commands/listNamespaces.js
+++ b/src/client/cli/commands/listNamespaces.js
@@ -1,0 +1,17 @@
+// @flow
+
+const RestClient = require('../../api/RestClient')
+const { subcommand } = require('../util')
+
+module.exports = {
+  command: 'listNamespaces',
+  description: `Fetch a list of namespaces published by all known peers.\n`,
+  handler: subcommand((opts: {client: RestClient}) => {
+    const {client} = opts
+    return client.listNamespaces().then(
+      namespaces => {
+        namespaces.forEach(ns => console.log(ns))
+      }
+    )
+  })
+}

--- a/src/client/cli/commands/listPeers.js
+++ b/src/client/cli/commands/listPeers.js
@@ -11,13 +11,24 @@ module.exports = {
       alias: 'i',
       default: false,
       description: 'Also fetch the "info" string for each peer.  This requires an extra network request per-peer.\n'
+    },
+    namespace: {
+      type: 'string',
+      description: 'If given, only return peers that have published to the given namespace. ' +
+       `Can use wildcards, e.g. 'images.*'\n`
+    },
+    includeSelf: {
+      type: 'boolean',
+      alias: 'all',
+      description: 'Include the local node in namespace listings.  Has no effect if --namespace is not present.\n',
+      default: false
     }
   },
   description: `Fetch a list of remote peers from the directory server. The local node must be ` +
     `configured to use a directory server.\n`,
-  handler: subcommand((opts: {client: RestClient, info: boolean}) => {
-    const {client, info} = opts
-    return client.listPeers().then(
+  handler: subcommand((opts: {client: RestClient, info: boolean, namespace?: string, includeSelf: boolean}) => {
+    const {client, info, namespace, includeSelf} = opts
+    return client.listPeers(namespace, includeSelf).then(
       peers => {
         if (info) {
           return fetchInfos(client, peers)

--- a/src/client/cli/commands/listPeers.js
+++ b/src/client/cli/commands/listPeers.js
@@ -6,7 +6,7 @@ const { subcommand } = require('../util')
 type Opts = {client: RestClient, info: boolean, namespace?: string, includeSelf: boolean}
 
 module.exports = {
-  command: 'listPeers',
+  command: 'listPeers [namespace]',
   builder: {
     info: {
       type: 'boolean',
@@ -14,20 +14,16 @@ module.exports = {
       default: false,
       description: 'Also fetch the "info" string for each peer.  This requires an extra network request per-peer.\n'
     },
-    namespace: {
-      type: 'string',
-      description: 'If given, only return peers that have published to the given namespace. ' +
-       `Can use wildcards, e.g. 'images.*'\n`
-    },
     includeSelf: {
       type: 'boolean',
       alias: 'all',
-      description: 'Include the local node in namespace listings.  Has no effect if --namespace is not present.\n',
+      description: 'Include the local node in namespace listings.  Has no effect if namespace is not given.\n',
       default: false
     }
   },
-  description: `Fetch a list of remote peers from the directory server. The local node must be ` +
-    `configured to use a directory server.\n`,
+  description: 'Fetch a list of remote peers from a directory server or the DHT. ' +
+    'If the `namespace` argument is given, only peers that have published to the given namespace will be returned. ' +
+    'Namespace listings require the node to be configured to use a directory server.\n',
   handler: subcommand((opts: Opts) => {
     const {client, info, namespace} = opts
     let {includeSelf} = opts

--- a/src/peer/constants.js
+++ b/src/peer/constants.js
@@ -12,6 +12,7 @@ const PROTOCOLS = {
   },
   dir: {
     list: '/mediachain/dir/list',
+    listns: '/mediachain/dir/listns',
     lookup: '/mediachain/dir/lookup',
     register: '/mediachain/dir/register'
   }

--- a/src/protobuf/dir.proto
+++ b/src/protobuf/dir.proto
@@ -2,13 +2,19 @@ syntax = "proto3";
 package proto;
 
 message PeerInfo {
-  string id = 1;            // peer id
-  repeated bytes addr = 2;  // peer multiaddrs
+  string id = 1;                   // peer id
+  repeated bytes addr = 2;         // peer multiaddrs
+}
+
+message PublisherInfo {
+  string id = 1;                   // publisher id
+  repeated string namespaces = 2;  // namespaces in peer's store
 }
 
 // /mediachain/dir/register
 message RegisterPeer {
   PeerInfo info = 1;
+  PublisherInfo publisher = 2;     // optional (v1.4)
 }
 
 // /mediachain/dir/lookup
@@ -17,13 +23,21 @@ message LookupPeerRequest {
 }
 
 message LookupPeerResponse {
-  PeerInfo peer = 1;       // abset if peer not found
+  PeerInfo peer = 1;               // absent if peer not found
 }
 
 // /mediachain/dir/list
 message ListPeersRequest {
+  string namespace = 1;            // optional (v1.4); peers in namespace
 }
 
 message ListPeersResponse {
   repeated string peers = 1;
+}
+
+// /mediachain/dir/listns
+message ListNamespacesRequest {}
+
+message ListNamespacesResponse {
+  repeated string namespaces = 1;
 }

--- a/src/protobuf/index.js
+++ b/src/protobuf/index.js
@@ -7,6 +7,7 @@ const protobuf = require('protocol-buffers')
 import type {
   ProtoCodec,
   PeerInfoMsg,
+  PublisherInfoMsg,
   RegisterPeerMsg,
   LookupPeerRequestMsg,
   LookupPeerResponseMsg,
@@ -44,6 +45,7 @@ import type {
 type AllProtos = {
   dir: {
     PeerInfo: ProtoCodec<PeerInfoMsg>,
+    PublisherInfo: ProtoCodec<PublisherInfoMsg>,
     RegisterPeer: ProtoCodec<RegisterPeerMsg>,
     LookupPeerRequest: ProtoCodec<LookupPeerRequestMsg>,
     LookupPeerResponse: ProtoCodec<LookupPeerResponseMsg>,
@@ -105,6 +107,7 @@ function loadProtos (): AllProtos {
   return {
     dir: {
       PeerInfo: pb.PeerInfo,
+      PublisherInfo: pb.PublisherInfo,
       RegisterPeer: pb.RegisterPeer,
       LookupPeerRequest: pb.LookupPeerRequest,
       LookupPeerResponse: pb.LookupPeerResponse,

--- a/src/protobuf/types.js
+++ b/src/protobuf/types.js
@@ -7,8 +7,14 @@ export type PeerInfoMsg = {
   addr: Array<Buffer>
 }
 
+export type PublisherInfoMsg = {
+  id: string,
+  namespaces: Array<string>
+}
+
 export type RegisterPeerMsg = {
-  info: PeerInfoMsg
+  info: PeerInfoMsg,
+  publisher?: PublisherInfoMsg
 }
 
 export type LookupPeerRequestMsg = {
@@ -20,6 +26,7 @@ export type LookupPeerResponseMsg = {
 }
 
 export type ListPeersRequestMsg = {
+  namespace?: string
 }
 
 export type ListPeersResponseMsg = {


### PR DESCRIPTION
Adds support for https://github.com/mediachain/concat/pull/101

- Adds `mcclient listNamespaces`

<details>
<summary> list namespaces example</summary>

```
$ mcclient listNamespaces
images.500px
images.dpla
images.flickr
images.pexels
mediachain.schemas
museums.brooklynmuseum.artists
museums.brooklynmuseum.collections
museums.brooklynmuseum.exhibitions
museums.brooklynmuseum.geographicallocations
museums.brooklynmuseum.museumlocations
museums.brooklynmuseum.objects
museums.cooperhewitt.objects
museums.moma.artists
museums.moma.artworks
museums.rijksmuseum.artworks
museums.tate.artists
museums.tate.artworks
```
</details>

- Adds `namespace` argument to `mcclient listPeers` to return peers that publish to given namespace:

```
$ mcclient listPeers --info 'images.500px'
QmeiY2eHMwK92Zt6X4kUUC3MsjMmVb2VnGZ17DhnhRPCEQ -- Metadata for CC images from DPLA, 500px, and pexels; operated by Mediachain Labs.
```

- Adds `--includeSelf` (aliased to `--all`) flag to include self in namespace listings (useful to verify that your stuff is visible):

```
$ mcclient listPeers --includeSelf --info 'museums.*'
QmXY1nyb6sbXgdAjEjDHcqXfpmmwjhj3S1KPSu94grp1xo (self) -- Yusef's test node
QmTVsocFCSEdPyM8dZ734GRhjvvmYyL9fShyezVkbPj17E -- Curated Museum Metadata; Operated by Mediachain Labs
```
