### PR TITLE
Add global `--timeout` flag to set request timeout

### DIFF
--- a/src/client/cli/index.js
+++ b/src/client/cli/index.js
@@ -14,8 +14,15 @@ yargs
   .option('sshConfig', {
     description: 'Path to a configuration file for SSH tunnelling, e.g. the credentials file created by Mediachain Deploy'
   })
+  .option('timeout', {
+    type: 'number',
+    description: `Timeout (in seconds), to use for requests to the mediachain node's API.`,
+    default: 15,
+    coerce: seconds => Math.floor(seconds * 1000) // convert to milliseconds for easier consumption
+  })
   .global('apiUrl')
   .global('sshConfig')
+  .global('timeout')
   .commandDir('commands')
   .strict()
   .wrap(yargs.terminalWidth())

--- a/src/client/cli/util.js
+++ b/src/client/cli/util.js
@@ -94,7 +94,8 @@ function prepareSSHConfig (config: Object | string): Object {
 
 type GlobalOptions = {
   apiUrl: string,
-  sshConfig?: string | Object
+  sshConfig?: string | Object,
+  timeout: number
 }
 
 type SubcommandGlobalOptions = { // eslint-disable-line no-unused-vars
@@ -103,8 +104,8 @@ type SubcommandGlobalOptions = { // eslint-disable-line no-unused-vars
 
 function subcommand<T: SubcommandGlobalOptions> (handler: (argv: T) => Promise<*>): (argv: GlobalOptions) => void {
   return (argv: GlobalOptions) => {
-    const {apiUrl, sshConfig} = argv
-    const client = new RestClient({apiUrl})
+    const {apiUrl, sshConfig, timeout} = argv
+    const client = new RestClient({apiUrl, requestTimeout: timeout})
 
     const sshTunnelConfig = (sshConfig != null)
       ? prepareSSHConfig(sshConfig)


### PR DESCRIPTION
This adds a new global `--timeout` argument to set the timeout (in seconds) for requests to the mcnode api.  

Thanks to the `subcommand` helper I made earlier, I only had to change two files, so that's nice :)