### PR TITLE
Fix memory leak in publish command

### DIFF
--- a/src/client/cli/commands/auth/grant.js
+++ b/src/client/cli/commands/auth/grant.js
@@ -1,7 +1,7 @@
 // @flow
 
 const RestClient = require('../../../api/RestClient')
-const { subcommand, printJSON } = require('../../util')
+const { subcommand, printJSON, println } = require('../../util')
 
 module.exports = {
   command: 'grant <peerId> <namespaces..>',
@@ -16,7 +16,7 @@ module.exports = {
     return client.authorize(peerId, namespaces)
       .then(() => client.getAuthorizations())
       .then(auths => {
-        console.log(`Granted authorizations for peer ${peerId}:`)
+        println(`Granted authorizations for peer ${peerId}:`)
         printJSON(auths[peerId])
       })
   })

--- a/src/client/cli/commands/auth/revoke.js
+++ b/src/client/cli/commands/auth/revoke.js
@@ -1,7 +1,7 @@
 // @flow
 
 const RestClient = require('../../../api/RestClient')
-const { subcommand } = require('../../util')
+const { subcommand, println } = require('../../util')
 
 module.exports = {
   command: 'revoke <peerId>',
@@ -10,6 +10,6 @@ module.exports = {
     const {apiUrl, peerId} = opts
     const client = new RestClient({apiUrl})
     return client.revokeAuthorization(peerId)
-      .then(() => { console.log(`Revoked authorization for ${peerId}.`) })
+      .then(() => { println(`Revoked authorization for ${peerId}.`) })
   })
 }

--- a/src/client/cli/commands/config/dir.js
+++ b/src/client/cli/commands/config/dir.js
@@ -1,7 +1,7 @@
 // @flow
 
 const RestClient = require('../../../api/RestClient')
-const { subcommand } = require('../../util')
+const { subcommand, println } = require('../../util')
 
 module.exports = {
   command: 'dir [dirId]',
@@ -11,11 +11,11 @@ module.exports = {
     if (dirId) {
       return client.setDirectoryId(dirId)
         .then(() => {
-          console.log(`set directory to ${dirId}`)
+          println(`set directory to ${dirId}`)
         })
     } else {
       return client.getDirectoryId()
-        .then(console.log)
+        .then(println)
     }
   })
 }

--- a/src/client/cli/commands/config/info.js
+++ b/src/client/cli/commands/config/info.js
@@ -1,7 +1,7 @@
 // @flow
 
 const RestClient = require('../../../api/RestClient')
-const { subcommand } = require('../../util')
+const { subcommand, println } = require('../../util')
 
 module.exports = {
   command: 'info [peerInfo]',
@@ -11,11 +11,11 @@ module.exports = {
     if (peerInfo) {
       return client.setInfo(peerInfo)
         .then(() => {
-          console.log(`set peer info to "${peerInfo}"`)
+          println(`set peer info to "${peerInfo}"`)
         })
     } else {
       return client.getInfo()
-        .then(console.log)
+        .then(println)
     }
   })
 }

--- a/src/client/cli/commands/config/nat.js
+++ b/src/client/cli/commands/config/nat.js
@@ -1,7 +1,7 @@
 // @flow
 
 const RestClient = require('../../../api/RestClient')
-const { subcommand } = require('../../util')
+const { subcommand, println } = require('../../util')
 
 module.exports = {
   command: 'nat [natConfig]',
@@ -11,14 +11,14 @@ module.exports = {
     if (natConfig) {
       return client.setNATConfig(natConfig)
         .then(() => {
-          console.log(`set NAT configuration to "${natConfig}"`)
+          println(`set NAT configuration to "${natConfig}"`)
         })
         .catch(err => {
           throw new Error(`Error setting NAT configuration: ${err.message}`)
         })
     } else {
       return client.getNATConfig()
-        .then(console.log)
+        .then(println)
     }
   })
 }

--- a/src/client/cli/commands/data/compact.js
+++ b/src/client/cli/commands/data/compact.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type {RestClient} from '../../../api'
-const {subcommand} = require('../../util')
+const {subcommand, println} = require('../../util')
 
 module.exports = {
   command: 'compact',
@@ -10,7 +10,7 @@ module.exports = {
     const {client} = opts
     return client.compactDatastore()
       .then(() => {
-        console.log('Compaction successful')
+        println('Compaction successful')
       })
   })
 }

--- a/src/client/cli/commands/data/gc.js
+++ b/src/client/cli/commands/data/gc.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type {RestClient} from '../../../api'
-const {subcommand, pluralizeCount} = require('../../util')
+const {subcommand, pluralizeCount, println} = require('../../util')
 
 module.exports = {
   command: 'gc',
@@ -10,7 +10,7 @@ module.exports = {
     const {client} = opts
     return client.garbageCollectDatastore()
       .then(count => {
-        console.log(`Garbage collected ${pluralizeCount(count, 'object')}`)
+        println(`Garbage collected ${pluralizeCount(count, 'object')}`)
       })
   })
 }

--- a/src/client/cli/commands/data/keys.js
+++ b/src/client/cli/commands/data/keys.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type {RestClient} from '../../../api'
-const {subcommand} = require('../../util')
+const {subcommand, println} = require('../../util')
 
 module.exports = {
   command: 'keys',
@@ -10,7 +10,7 @@ module.exports = {
     const {client} = opts
     return client.getDatastoreKeyStream()
       .then(stream => new Promise((resolve, reject) => {
-        stream.on('data', data => { console.log(data.toString()) })
+        stream.on('data', data => { println(data.toString()) })
         stream.on('error', reject)
         stream.on('end', () => resolve())
       }))

--- a/src/client/cli/commands/data/put.js
+++ b/src/client/cli/commands/data/put.js
@@ -3,7 +3,7 @@
 const fs = require('fs')
 const ndjson = require('ndjson')
 const RestClient = require('../../../api/RestClient')
-const { subcommand } = require('../../util')
+const { subcommand, println } = require('../../util')
 import type { Readable } from 'stream'
 
 const BATCH_SIZE = 1000
@@ -56,7 +56,7 @@ module.exports = {
 function putItems (client: RestClient, items: Array<Object>): Promise<*> {
   return client.putData(...items).then(
     hashes => {
-      hashes.forEach(h => console.log(h))
+      hashes.forEach(h => println(h))
     }
   )
 }

--- a/src/client/cli/commands/data/sync.js
+++ b/src/client/cli/commands/data/sync.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type {RestClient} from '../../../api'
-const {subcommand} = require('../../util')
+const {subcommand, println} = require('../../util')
 
 module.exports = {
   command: 'sync',
@@ -10,7 +10,7 @@ module.exports = {
     const {client} = opts
     return client.syncDatastore()
       .then(count => {
-        console.log(`Sync successful`)
+        println(`Sync successful`)
       })
   })
 }

--- a/src/client/cli/commands/delete.js
+++ b/src/client/cli/commands/delete.js
@@ -1,7 +1,7 @@
 // @flow
 
 const RestClient = require('../../api/RestClient')
-const { subcommand, pluralizeCount } = require('../util')
+const { subcommand, pluralizeCount, println } = require('../util')
 
 module.exports = {
   command: 'delete <queryString>',
@@ -11,7 +11,7 @@ module.exports = {
 
     return client.delete(queryString)
       .then(count => {
-        console.log(`Deleted ${pluralizeCount(count, 'statement')}`)
+        println(`Deleted ${pluralizeCount(count, 'statement')}`)
       })
   })
 }

--- a/src/client/cli/commands/id.js
+++ b/src/client/cli/commands/id.js
@@ -1,7 +1,7 @@
 // @flow
 
 const RestClient = require('../../api/RestClient')
-const {subcommand} = require('../util')
+const {subcommand, println} = require('../util')
 
 module.exports = {
   command: 'id [peerId]',
@@ -16,7 +16,7 @@ module.exports = {
 
 function printIds (opts: {peer: string, publisher: string, info: string}) {
   const {peer, publisher, info} = opts
-  console.log(`Peer ID: ${peer}`)
-  console.log(`Publisher ID: ${publisher}`)
-  console.log(`Info: ${info}`)
+  println(`Peer ID: ${peer}`)
+  println(`Publisher ID: ${publisher}`)
+  println(`Info: ${info}`)
 }

--- a/src/client/cli/commands/listNamespaces.js
+++ b/src/client/cli/commands/listNamespaces.js
@@ -1,7 +1,7 @@
 // @flow
 
 const RestClient = require('../../api/RestClient')
-const { subcommand } = require('../util')
+const { subcommand, println } = require('../util')
 
 module.exports = {
   command: 'listNamespaces',
@@ -10,7 +10,7 @@ module.exports = {
     const {client} = opts
     return client.listNamespaces().then(
       namespaces => {
-        namespaces.sort().forEach(ns => console.log(ns))
+        namespaces.sort().forEach(ns => println(ns))
       }
     )
   })

--- a/src/client/cli/commands/listPeers.js
+++ b/src/client/cli/commands/listPeers.js
@@ -1,7 +1,7 @@
 // @flow
 
 const RestClient = require('../../api/RestClient')
-const { subcommand } = require('../util')
+const { subcommand, println } = require('../util')
 
 type Opts = {client: RestClient, info: boolean, namespace?: string, includeSelf: boolean}
 
@@ -36,7 +36,7 @@ module.exports = {
         if (info) {
           return fetchInfos(peers, opts)
         } else {
-          peers.forEach(p => console.log(p))
+          peers.forEach(p => println(p))
         }
       }
     )
@@ -49,7 +49,7 @@ function printInfo (ids: Object, isSelf: boolean = false) {
     msg = ids.info
   }
   const selfMsg = isSelf ? '(self) ' : ''
-  console.log(`${ids.peer} ${selfMsg}-- ${msg}`)
+  println(`${ids.peer} ${selfMsg}-- ${msg}`)
 }
 
 function fetchInfos (peerIds: Array<string>, opts: Opts): Promise<*> {
@@ -72,7 +72,7 @@ function fetchInfos (peerIds: Array<string>, opts: Opts): Promise<*> {
         promises.push(
           client.id(peer)
             .then(printInfo)
-            .catch(err => { console.log(`${peer} -- Unable to fetch info: ${err.message}`) })
+            .catch(err => { println(`${peer} -- Unable to fetch info: ${err.message}`) })
         )
       }
     }

--- a/src/client/cli/commands/lookupPeer.js
+++ b/src/client/cli/commands/lookupPeer.js
@@ -1,7 +1,7 @@
 // @flow
 
 const RestClient = require('../../api/RestClient')
-const { subcommand } = require('../util')
+const { subcommand, println } = require('../util')
 
 module.exports = {
   command: 'lookupPeer <peerId>',
@@ -13,7 +13,7 @@ module.exports = {
     return client.netLookup(peerId)
       .then(
         addrs => {
-          addrs.forEach(a => { console.log(a) })
+          addrs.forEach(a => { println(a) })
         },
         err => { throw new Error(`Error during peer lookup: ${err.message}`) }
       )

--- a/src/client/cli/commands/merge.js
+++ b/src/client/cli/commands/merge.js
@@ -1,7 +1,7 @@
 // @flow
 
 const RestClient = require('../../api/RestClient')
-const { subcommand, pluralizeCount } = require('../util')
+const { subcommand, pluralizeCount, println } = require('../util')
 
 module.exports = {
   command: 'merge <remotePeer> <queryString>',
@@ -12,7 +12,7 @@ module.exports = {
 
     return client.merge(queryString, remotePeer)
       .then(({statementCount, objectCount}) => {
-        console.log(
+        println(
           `merged ${pluralizeCount(statementCount, 'statement')} and ${pluralizeCount(objectCount, 'object')}`
         )
       })

--- a/src/client/cli/commands/netAddr.js
+++ b/src/client/cli/commands/netAddr.js
@@ -1,7 +1,7 @@
 // @flow
 
 const RestClient = require('../../api/RestClient')
-const { subcommand } = require('../util')
+const { subcommand, println } = require('../util')
 
 module.exports = {
   command: 'netAddr [peerId]',
@@ -15,15 +15,15 @@ module.exports = {
         addresses => {
           if (addresses.length < 1) {
             if (peerId != null) {
-              console.warn(`No known addresses for peer ${peerId}`)
+              println(`No known addresses for peer ${peerId}`)
             } else {
-              console.warn(
+              println(
                 'Local node does not have an address. Make sure status is set to "online" or "public"'
               )
             }
           } else {
             addresses.forEach(addr => {
-              console.log(addr)
+              println(addr)
             })
           }
         })

--- a/src/client/cli/commands/netConnections.js
+++ b/src/client/cli/commands/netConnections.js
@@ -1,7 +1,7 @@
 // @flow
 
 const RestClient = require('../../api/RestClient')
-const { subcommand } = require('../util')
+const { subcommand, println } = require('../util')
 
 module.exports = {
   command: 'netConnections',
@@ -13,12 +13,12 @@ module.exports = {
       .then(
         addresses => {
           if (addresses.length < 1) {
-            console.log(
+            println(
               'No active network connections.  Is the node online?'
             )
           } else {
             addresses.forEach(addr => {
-              console.log(addr)
+              println(addr)
             })
           }
         })

--- a/src/client/cli/commands/ping.js
+++ b/src/client/cli/commands/ping.js
@@ -1,7 +1,7 @@
 // @flow
 
 const RestClient = require('../../api/RestClient')
-const { subcommand } = require('../util')
+const { subcommand, println } = require('../util')
 
 module.exports = {
   command: 'ping <peerId>',
@@ -9,11 +9,11 @@ module.exports = {
   'Will attempt to lookup the peer with a configured directory server or DHT.\n',
   handler: subcommand((opts: {peerId: string, client: RestClient}) => {
     const {peerId, client} = opts
-    console.log('Pinging peer: ', peerId)
+    println('Pinging peer: ', peerId)
 
     return client.ping(peerId)
       .then(
-        success => console.log('Ping OK'),
+        success => println('Ping OK'),
         err => { throw new Error(`Error pinging: ${err.message}`) }
       )
   })

--- a/src/client/cli/commands/publishRaw.js
+++ b/src/client/cli/commands/publishRaw.js
@@ -1,7 +1,7 @@
 // @flow
 
 const RestClient = require('../../api/RestClient')
-const { subcommand } = require('../util')
+const { subcommand, println } = require('../util')
 
 module.exports = {
   command: 'publishRaw <namespace> <statementBodyId>',
@@ -13,6 +13,6 @@ module.exports = {
     const {client, namespace, statementBodyId} = opts
 
     return client.publish({namespace}, {object: statementBodyId})
-      .then(console.log)
+      .then(objectIds => objectIds.forEach(println))
   })
 }

--- a/src/client/cli/commands/publishSchema.js
+++ b/src/client/cli/commands/publishSchema.js
@@ -1,7 +1,7 @@
 // @flow
 
 const RestClient = require('../../api/RestClient')
-const { subcommand } = require('../util')
+const { subcommand, println } = require('../util')
 const { loadSelfDescribingSchema, schemaDescriptionToWKI } = require('../../../metadata/schema')
 
 const SCHEMA_NAMESPACE = 'mediachain.schemas'
@@ -27,9 +27,9 @@ module.exports = {
       .then(([objectId]) =>
         client.publish({namespace}, {object: objectId, refs: [wki]})
           .then(([statementId]) => {
-            console.log(`Published schema with wki = ${wki} to namespace ${namespace}`)
-            console.log(`Object ID: ${objectId}`)
-            console.log(`Statement ID: ${statementId}`)
+            println(`Published schema with wki = ${wki} to namespace ${namespace}`)
+            println(`Object ID: ${objectId}`)
+            println(`Statement ID: ${statementId}`)
           }))
   })
 }

--- a/src/client/cli/commands/push.js
+++ b/src/client/cli/commands/push.js
@@ -1,7 +1,7 @@
 // @flow
 
 const RestClient = require('../../api/RestClient')
-const { subcommand, pluralizeCount } = require('../util')
+const { subcommand, pluralizeCount, println } = require('../util')
 
 module.exports = {
   command: 'push <remotePeer> <queryString>',
@@ -13,7 +13,7 @@ module.exports = {
 
     return client.push(queryString, remotePeer)
       .then(({statementCount, objectCount}) => {
-        console.log(
+        println(
           `Pushed ${pluralizeCount(statementCount, 'statement')} and ${pluralizeCount(objectCount, 'object')}`
         )
       })

--- a/src/client/cli/commands/shutdown.js
+++ b/src/client/cli/commands/shutdown.js
@@ -1,7 +1,7 @@
 // @flow
 
 const RestClient = require('../../api/RestClient')
-const { subcommand } = require('../util')
+const { subcommand, println } = require('../util')
 
 module.exports = {
   command: 'shutdown',
@@ -9,7 +9,7 @@ module.exports = {
   handler: subcommand((opts: {client: RestClient}) => {
     const {client} = opts
     return client.shutdown().then(
-      console.log('Node shutdown successfully')
+      println('Node shutdown successfully')
     )
   })
 }

--- a/src/client/cli/commands/status.js
+++ b/src/client/cli/commands/status.js
@@ -1,7 +1,7 @@
 // @flow
 
 const RestClient = require('../../api/RestClient')
-const { subcommand } = require('../util')
+const { subcommand, println } = require('../util')
 import type { NodeStatus } from '../../api/RestClient'
 
 module.exports = {
@@ -13,7 +13,7 @@ module.exports = {
     const {client, newStatus} = opts
 
     if (!newStatus) {
-      return client.getStatus().then(console.log)
+      return client.getStatus().then(println)
     }
 
     let status: NodeStatus
@@ -30,7 +30,7 @@ module.exports = {
     }
     return client.setStatus(status)
       .then(returnedStatus => {
-        console.log(`status set to ${returnedStatus}`)
+        println(`status set to ${returnedStatus}`)
       })
   })
 }

--- a/src/client/cli/commands/validate.js
+++ b/src/client/cli/commands/validate.js
@@ -5,7 +5,7 @@ const path = require('path')
 const RestClient = require('../../api/RestClient')
 const { JQTransform } = require('../../../metadata/jqStream')
 const { validate, loadSelfDescribingSchema, validateSelfDescribingSchema } = require('../../../metadata/schema')
-const { subcommand, pluralizeCount, isB58Multihash } = require('../util')
+const { subcommand, pluralizeCount, isB58Multihash, println } = require('../util')
 import type { Readable } from 'stream'
 import type { SelfDescribingSchema } from '../../../metadata/schema'
 
@@ -114,7 +114,7 @@ function validateStream (opts: {
         return reject(new Error(`Error reading from ${streamName}: ${err.message}`))
       })
       .on('end', () => {
-        console.log(`${pluralizeCount(count, 'statement')} validated successfully`)
+        println(`${pluralizeCount(count, 'statement')} validated successfully`)
         resolve()
       })
   })

--- a/src/client/cli/util.js
+++ b/src/client/cli/util.js
@@ -7,6 +7,8 @@ const { JQ_PATH } = require('../../metadata/jqStream')
 const childProcess = require('child_process')
 const sshTunnel = require('tunnel-ssh')
 const { RestClient } = require('../api')
+import type { Writable } from 'stream'
+import type { WriteStream } from 'tty'
 
 function formatJSON (obj: ?mixed,
                     options: {color?: ?boolean, pretty?: boolean} = {}): string {
@@ -140,7 +142,39 @@ function subcommand<T: SubcommandGlobalOptions> (handler: (argv: T) => Promise<*
   }
 }
 
+/**
+ * Print `output` to the `destination` stream and append a newline.
+ * @param output
+ * @param destination
+ */
+function writeln (output: string, destination: Writable | WriteStream) {
+  destination.write(output + '\n')
+}
+
+/**
+ * Print `output` to stdout and append a newline.
+ * Always use this instead of console.log for non-debug output!
+ * console.log keeps a strong reference to whatever you pass in,
+ * which can result in memory leaks for long-running processes.
+ * @param output
+ */
+function println (output: string) {
+  writeln(output, process.stdout)
+}
+
+/**
+ * Print `output` to stderr and append a newline.
+ * Use if you don't want console.error to keep a strong reference
+ * to whatever you pass in.
+ * @param output
+ */
+function printlnErr (output: string) {
+  writeln(output, process.stderr)
+}
+
 module.exports = {
+  println,
+  printlnErr,
   formatJSON,
   printJSON,
   pluralizeCount,


### PR DESCRIPTION
It turns out that [console.log retains its arguments indefinitely](http://stackoverflow.com/a/13001962) and prevents them from being GC'd, so you can do fancy things with them like inspect them in dev tools.

This was causing us to eventually run out of heap space when publishing millions of records, since I was using `console.log` to output the statment ids, etc.

This adds a `println` utility function that calls `process.stdout.write`, and replaces all the `console.log`s with `println`. A lot of the console.logs wouldn't matter, since they're in one-off commands like `mcclient id`, but I kind of wanted to burn them all to the ground after chasing this leak all day 😄

There's a few other changes to the publish command:

- instead of accumulating all promises for each batch publication and waiting on `Promise.all`, we only keep "in-flight" batch promises in a map and remove them when they resolve.  Then when the input stream ends we just wait until the map is empty.  This lets us avoid keeping thousands of promises around during huge ingestions.

- I was using `Array.slice` needlessly (and confusingly) when printing the batch results, which was allocating objects for no good reason.  I replaced that with a for loop

- I'm now closing the input stream and killing the jq process on errors, before rejecting the main promise.  Seems like a good idea.

Something I noticed is that for giant ingestions, the default timeout can be too low; I'll get timeouts on `data/put` commands if I'm a few million records in.  Changing the global timeout works, but we should probably add some backoff / retry logic for things like putting data.