### PR TITLE
Allow getting/setting multiple directory servers

### DIFF
--- a/integration-test/util.js
+++ b/integration-test/util.js
@@ -61,7 +61,7 @@ function concatNodeClient (): Promise<RestClient> {
 function setConcatNodeDirectoryInfo (): Promise<*> {
   return Promise.all([concatNodeClient(), directoryMultiaddr(), directoryPeerId()])
     .then(([client, dirAddr, dirId]) => {
-      return client.setDirectoryId(dirAddr.toString() + '/' + dirId.toB58String())
+      return client.setDirectoryIds(dirAddr.toString() + '/p2p/' + dirId.toB58String())
     })
 }
 

--- a/src/client/api/RestClient.js
+++ b/src/client/api/RestClient.js
@@ -276,13 +276,13 @@ class RestClient {
       .then(validateStatus)
   }
 
-  getDirectoryId (): Promise<string> {
+  getDirectoryIds (): Promise<Array<string>> {
     return this.getRequest('config/dir')
-      .then(trimTextResponse)
+      .then(parseStringArrayResponse)
   }
 
-  setDirectoryId (id: string): Promise<boolean> {
-    return this.postRequest('config/dir', id, false)
+  setDirectoryIds (...ids: Array<string>): Promise<boolean> {
+    return this.postRequest('config/dir', ids.join('\n'), false)
       .then(() => true)
   }
 

--- a/src/client/cli/commands/config/dir.js
+++ b/src/client/cli/commands/config/dir.js
@@ -6,17 +6,29 @@ const { subcommand, println, pluralizeCount } = require('../../util')
 module.exports = {
   command: 'dir [dirIds..]',
   description: 'Get or set the directory servers.\n',
-  handler: subcommand((opts: {client: RestClient, dirIds: Array<string>}) => {
-    const {client, dirIds} = opts
+  builder: {
+    clear: {
+      type: 'boolean',
+      description: 'If given, clear out the existing directory configuration.\n'
+    }
+  },
+  handler: subcommand((opts: {client: RestClient, dirIds: Array<string>, clear?: boolean}) => {
+    const {client, dirIds, clear} = opts
+
+    if (clear) {
+      return client.setDirectoryIds()
+        .then(() => println('Directory configuration cleared'))
+    }
+
     if (dirIds.length > 0) {
       return client.setDirectoryIds(...dirIds)
         .then(() => {
           println(`Set ${pluralizeCount(dirIds.length, 'directory server')}:`)
           dirIds.forEach(println)
         })
-    } else {
-      return client.getDirectoryIds()
-        .then(ids => ids.forEach(println))
     }
+
+    return client.getDirectoryIds()
+      .then(ids => ids.forEach(println))
   })
 }

--- a/src/client/cli/commands/config/dir.js
+++ b/src/client/cli/commands/config/dir.js
@@ -1,21 +1,22 @@
 // @flow
 
 const RestClient = require('../../../api/RestClient')
-const { subcommand, println } = require('../../util')
+const { subcommand, println, pluralizeCount } = require('../../util')
 
 module.exports = {
-  command: 'dir [dirId]',
-  description: 'Get or set the directory server id.\n',
-  handler: subcommand((opts: {client: RestClient, dirId?: string}) => {
-    const {client, dirId} = opts
-    if (dirId) {
-      return client.setDirectoryId(dirId)
+  command: 'dir [dirIds..]',
+  description: 'Get or set the directory servers.\n',
+  handler: subcommand((opts: {client: RestClient, dirIds: Array<string>}) => {
+    const {client, dirIds} = opts
+    if (dirIds.length > 0) {
+      return client.setDirectoryIds(...dirIds)
         .then(() => {
-          println(`set directory to ${dirId}`)
+          println(`Set ${pluralizeCount(dirIds.length, 'directory server')}:`)
+          dirIds.forEach(println)
         })
     } else {
-      return client.getDirectoryId()
-        .then(println)
+      return client.getDirectoryIds()
+        .then(ids => ids.forEach(println))
     }
   })
 }


### PR DESCRIPTION
`mcclient config dir` now accepts multiple directory addresses, and the `RestClient` methods have had their names and type signatures updated to support multiple directories.