### PR TITLE
Bind SSH tunnel to any open port

### DIFF
--- a/src/client/cli/util.js
+++ b/src/client/cli/util.js
@@ -70,20 +70,12 @@ function ensureAll (obj: Object, keys: Array<string>, description: string = 'obj
   }
 }
 
-function ensureAny (obj: Object, keys: Array<string>, description: string = 'object') {
-  for (const key of keys) {
-    if (obj[key] !== undefined) return
-  }
-  throw new Error(`${description} must have one of the following fields: ${keys.join(', ')}`)
-}
-
 function prepareSSHConfig (config: Object | string): Object {
   if (typeof config === 'string') {
     config = JSON.parse(fs.readFileSync(config, 'utf8'))
   }
 
   ensureAll(config, ['host', 'username'], 'SSH configuration')
-  ensureAny(config, ['password', 'privateKey'], 'SSH configuration')
 
   const defaultOpts = {
     dstPort: 9002,

--- a/src/client/cli/util.js
+++ b/src/client/cli/util.js
@@ -111,8 +111,14 @@ function subcommand<T: SubcommandGlobalOptions> (handler: (argv: T) => Promise<*
     if (sshTunnelConfig != null) {
       sshTunnelPromise = setupSSHTunnel(sshTunnelConfig)
         .then(tunnel => {
+          tunnel.on('error', err => {
+            console.error(`SSH Error: ${err.message}`)
+            tunnel.close()
+            process.exit(1)
+          })
+          const addr = tunnel.address()
+
           sshTunnel = tunnel
-          const addr = sshTunnel.address()
           apiUrl = `http://${addr.address}:${addr.port}`
         })
     } else {


### PR DESCRIPTION
This changes the SSH tunnel setup to bind to any available port, and rewrites the `apiUrl` to use the bound port before passing the `RestClient` to the subcommand worker functions.

This lets you tunnel to a remote node while a local node is bound to the default port, or run multiple tunneled commands in parallel.

It also removes the requirement that the `sshConfig` have either a `password` or `privateKey` field, which makes the tunnel lib fallback to using ssh-agent to authenticate.