### PR TITLE
Change default timeout to none

### DIFF
--- a/src/client/api/RestClient.js
+++ b/src/client/api/RestClient.js
@@ -10,7 +10,7 @@ import type { Transform as TransformStream, Duplex as DuplexStream, Readable as 
 import type { StatementMsg, SimpleStatementMsg } from '../../protobuf/types'
 export type NodeStatus = 'online' | 'offline' | 'public'
 
-const DEFAULT_REQUEST_TIMEOUT = 15000
+const DEFAULT_REQUEST_TIMEOUT = 0
 
 type FetchResponse = {
   text: () => Promise<string>,

--- a/src/client/api/RestClient.js
+++ b/src/client/api/RestClient.js
@@ -10,7 +10,7 @@ import type { Transform as TransformStream, Duplex as DuplexStream, Readable as 
 import type { StatementMsg, SimpleStatementMsg } from '../../protobuf/types'
 export type NodeStatus = 'online' | 'offline' | 'public'
 
-const DEFAULT_REQUEST_TIMEOUT = 0
+const DEFAULT_REQUEST_TIMEOUT = 15000
 
 type FetchResponse = {
   text: () => Promise<string>,

--- a/src/client/cli/index.js
+++ b/src/client/cli/index.js
@@ -14,12 +14,6 @@ yargs
   .option('sshConfig', {
     description: 'Path to a configuration file for SSH tunnelling, e.g. the credentials file created by Mediachain Deploy'
   })
-  .option('timeout', {
-    type: 'number',
-    description: `Timeout (in seconds), to use for requests to the mediachain node's API.`,
-    default: 15,
-    coerce: seconds => Math.floor(seconds * 1000) // convert to milliseconds for easier consumption
-  })
   .global('apiUrl')
   .global('sshConfig')
   .global('timeout')

--- a/src/client/cli/index.js
+++ b/src/client/cli/index.js
@@ -14,6 +14,12 @@ yargs
   .option('sshConfig', {
     description: 'Path to a configuration file for SSH tunnelling, e.g. the credentials file created by Mediachain Deploy'
   })
+  .option('timeout', {
+    type: 'number',
+    description: `Timeout (in seconds), to use for requests to the mediachain node's API.`,
+    default: 15,
+    coerce: seconds => Math.floor(seconds * 1000) // convert to milliseconds for easier consumption
+  })
   .global('apiUrl')
   .global('sshConfig')
   .global('timeout')

--- a/src/client/cli/index.js
+++ b/src/client/cli/index.js
@@ -17,7 +17,8 @@ yargs
   .option('timeout', {
     type: 'number',
     description: `Timeout (in seconds), to use for requests to the mediachain node's API.`,
-    default: 15,
+    default: 0,
+    defaultDescription: '0 (no timeout)',
     coerce: seconds => Math.floor(seconds * 1000) // convert to milliseconds for easier consumption
   })
   .global('apiUrl')

--- a/src/client/cli/util.js
+++ b/src/client/cli/util.js
@@ -89,7 +89,8 @@ function prepareSSHConfig (config: Object | string): Object {
 
 type GlobalOptions = {
   apiUrl: string,
-  sshConfig?: string | Object
+  sshConfig?: string | Object,
+  timeout: number
 }
 
 type SubcommandGlobalOptions = { // eslint-disable-line no-unused-vars
@@ -98,7 +99,7 @@ type SubcommandGlobalOptions = { // eslint-disable-line no-unused-vars
 
 function subcommand<T: SubcommandGlobalOptions> (handler: (argv: T) => Promise<*>): (argv: GlobalOptions) => void {
   return (argv: GlobalOptions) => {
-    const {sshConfig} = argv
+    const {sshConfig, timeout} = argv
     let {apiUrl} = argv
 
     const sshTunnelConfig = (sshConfig != null)
@@ -132,7 +133,7 @@ function subcommand<T: SubcommandGlobalOptions> (handler: (argv: T) => Promise<*
 
     sshTunnelPromise
       .then(() => {
-        const client = new RestClient({apiUrl})
+        const client = new RestClient({apiUrl, requestTimeout: timeout})
         return set(clone(argv), 'client', client)
       })
       .then(subcommandOptions => handler(subcommandOptions))

--- a/src/client/cli/util.js
+++ b/src/client/cli/util.js
@@ -89,8 +89,7 @@ function prepareSSHConfig (config: Object | string): Object {
 
 type GlobalOptions = {
   apiUrl: string,
-  sshConfig?: string | Object,
-  timeout: number
+  sshConfig?: string | Object
 }
 
 type SubcommandGlobalOptions = { // eslint-disable-line no-unused-vars
@@ -99,7 +98,7 @@ type SubcommandGlobalOptions = { // eslint-disable-line no-unused-vars
 
 function subcommand<T: SubcommandGlobalOptions> (handler: (argv: T) => Promise<*>): (argv: GlobalOptions) => void {
   return (argv: GlobalOptions) => {
-    const {sshConfig, timeout} = argv
+    const {sshConfig} = argv
     let {apiUrl} = argv
 
     const sshTunnelConfig = (sshConfig != null)
@@ -133,7 +132,7 @@ function subcommand<T: SubcommandGlobalOptions> (handler: (argv: T) => Promise<*
 
     sshTunnelPromise
       .then(() => {
-        const client = new RestClient({apiUrl, requestTimeout: timeout})
+        const client = new RestClient({apiUrl})
         return set(clone(argv), 'client', client)
       })
       .then(subcommandOptions => handler(subcommandOptions))


### PR DESCRIPTION
Per conversation with @vyzo in slack, the global request timeouts were causing a lot of problems for operations that take awhile to finish (e.g. publish, etc).

We talked about removing the global timeout and making certain operations opt-in, for example fetching the remote id for a peer.  I started to do that, but I couldn't come up with a compelling reason to keep the timeouts at all, versus just passing on the error from concat when its timeouts are exceeded.

With timeouts on the `mcclient` -> `mcnode` http connection, you get a confusing error message, and you may end up timing out before `mcnode` would have given you a more useful message.  I'm now thinking that if we're going to have a timeout parameter, it should be sent as part of the HTTP request (e.g in a query param), so that concat can alter *its* timeout.

Is there something I'm missing here, where timeouts on the API requests buy us something useful?