### PR TITLE
Basic test of signing / verifying buffers

### DIFF
--- a/src/peer/identity.js
+++ b/src/peer/identity.js
@@ -122,11 +122,38 @@ function generatePublisherId (): Promise<PublisherId> {
   })
 }
 
+function signBuffer (
+  key: PrivateSigningKey, // eslint-disable-line no-undef
+  message: Buffer)
+: Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    key.sign(message, (err, sig) => {
+      if (err) return reject(err)
+      resolve(sig)
+    })
+  })
+}
+
+function verifyBuffer (
+  key: PublicSigningKey, // eslint-disable-line no-undef
+  message: Buffer,
+  sig: Buffer)
+: Promise<boolean> {
+  return new Promise((resolve, reject) => {
+    key.verify(message, sig, (err, valid) => {
+      if (err) return reject(err)
+      resolve(valid)
+    })
+  })
+}
+
 module.exports = {
   generateIdentity,
   saveIdentity,
   loadIdentity,
   loadOrGenerateIdentity,
   inflateMultiaddr,
-  generatePublisherId
+  generatePublisherId,
+  signBuffer,
+  verifyBuffer
 }

--- a/test/signature_test.js
+++ b/test/signature_test.js
@@ -1,0 +1,34 @@
+// @flow
+// eslint-env mocha
+
+const assert = require('assert')
+const { before, describe, it } = require('mocha')
+
+const { generatePublisherId, signBuffer, verifyBuffer } = require('../src/peer/identity')
+
+describe('Signature verification', () => {
+  let publisherId
+
+  before(() =>
+    generatePublisherId()
+      .then(_pubId => { publisherId = _pubId })
+  )
+
+  it('signs and validates a buffer', () => {
+    const msg = Buffer.from(`You can get anything you want, at Alice's Restaurant`)
+    return signBuffer(publisherId.privateKey, msg)
+      .then(sig => verifyBuffer(publisherId.privateKey.public, msg, sig))
+      .then(result => {
+        assert(result === true, 'signature did not validate')
+      })
+  })
+
+  it('does not validate a modified buffer', () => {
+    const msg = Buffer.from(`Launch code: 0000`)
+    return signBuffer(publisherId.privateKey, msg)
+      .then(sig => verifyBuffer(publisherId.privateKey.public, Buffer.from('Launch code: 0001'), sig))
+      .then(result => {
+        assert(result === false, 'signature validated an invalid message')
+      })
+  })
+})


### PR DESCRIPTION
This is pretty barebones, but shows how to sign and verify with a PublisherId (which is just a wrapper around a libp2p-crypto PrivateKey).

I've got a couple mediachain statement specific verification methods on my merge branch; I'll add tests for those soon.