### PR TITLE
More ipfs interop

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,9 +9,9 @@
       "optional": true
     },
     "@types/node": {
-      "version": "6.0.56",
+      "version": "6.0.59",
       "from": "@types/node@>=6.0.45 <7.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.56.tgz"
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.59.tgz"
     },
     "abstract-leveldown": {
       "version": "2.4.1",
@@ -24,9 +24,9 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
     },
     "ajv": {
-      "version": "4.10.3",
+      "version": "4.10.4",
       "from": "ajv@>=4.9.2 <5.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.10.3.tgz"
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.10.4.tgz"
     },
     "amdefine": {
       "version": "1.0.1",
@@ -1186,9 +1186,9 @@
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
     },
     "keypair": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "from": "keypair@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/keypair/-/keypair-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/keypair/-/keypair-1.0.1.tgz"
     },
     "kind-of": {
       "version": "3.1.0",
@@ -1275,6 +1275,11 @@
       "version": "0.3.0",
       "from": "libp2p-identify@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/libp2p-identify/-/libp2p-identify-0.3.0.tgz"
+    },
+    "libp2p-ping": {
+      "version": "0.3.0",
+      "from": "libp2p-ping@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/libp2p-ping/-/libp2p-ping-0.3.0.tgz"
     },
     "libp2p-secio": {
       "version": "0.6.4",
@@ -3552,9 +3557,9 @@
       "resolved": "https://registry.npmjs.org/webcrypto/-/webcrypto-0.1.0.tgz"
     },
     "webcrypto-core": {
-      "version": "0.1.6",
+      "version": "0.1.7",
       "from": "webcrypto-core@>=0.0.0 <1.0.0",
-      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-0.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-0.1.7.tgz",
       "optional": true
     },
     "webcrypto-shim": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "knex": "^0.12.6",
     "levelup": "^1.3.3",
     "libp2p-crypto": "git://github.com/libp2p/js-libp2p-crypto.git#c45bdf602e765411d9d5fc2fddd45b31830f08e8",
+    "libp2p-ping": "^0.3.0",
     "libp2p-secio": "0.6.4",
     "libp2p-spdy": "0.10.1",
     "libp2p-swarm": "0.26.2",

--- a/src/client/api/RestClient.js
+++ b/src/client/api/RestClient.js
@@ -101,7 +101,12 @@ class RestClient {
 
   ping (peerId: string): Promise<boolean> {
     return this.getRequest(`ping/${peerId}`)
-      .then(response => true)
+      .then(parseBoolResponse)
+  }
+
+  netPing (peerId: string): Promise<string> {
+    return this.getRequest(`net/ping/${peerId}`)
+      .then(trimTextResponse)
   }
 
   publish (opts: {namespace: string, compound?: number}, ...statements: Array<SimpleStatementMsg>): Promise<Array<string>> {

--- a/src/client/api/RestClient.js
+++ b/src/client/api/RestClient.js
@@ -331,6 +331,11 @@ class RestClient {
       .then(parseStringArrayResponse)
   }
 
+  netIdentify (peerId: string): Promise<Object> {
+    return this.getRequest(`net/identify/${peerId}`)
+      .then(r => r.json())
+  }
+
   shutdown (): Promise<boolean> {
     return this.postRequest('shutdown', '', false)
       .then(() => true)

--- a/src/client/cli/commands/net.js
+++ b/src/client/cli/commands/net.js
@@ -1,0 +1,14 @@
+// @flow
+
+const path = require('path')
+
+module.exports = {
+  command: 'net <subcommand>',
+  description: 'Commands for inspecting and managing peer-to-peer network connections.\n',
+  builder: (yargs: Object) => yargs
+    .commandDir(path.join(__dirname, 'net'))
+    .help()
+    .strict(),
+
+  handler: () => {}
+}

--- a/src/client/cli/commands/net/addr.js
+++ b/src/client/cli/commands/net/addr.js
@@ -1,0 +1,34 @@
+// @flow
+
+const RestClient = require('../../../api/RestClient')
+const { subcommand, println } = require('../../util')
+
+module.exports = {
+  command: 'addr [peerId]',
+  description: `Print the local node's network addresses in multiaddr format. ` +
+  `If 'peerId' is given, prints the locally known addresses for that peer (useful for debugging).\n`,
+  handler: subcommand((opts: {client: RestClient, peerId?: string}) => {
+    const {client, peerId} = opts
+
+    return client.getNetAddresses(peerId)
+      .then(
+        addresses => {
+          if (addresses.length < 1) {
+            if (peerId != null) {
+              println(`No known addresses for peer ${peerId}`)
+            } else {
+              println(
+                'Local node does not have an address. Make sure status is set to "online" or "public"'
+              )
+            }
+          } else {
+            addresses.forEach(addr => {
+              println(addr)
+            })
+          }
+        })
+      .catch(
+        err => { throw new Error(`Error retrieving addresses: ${err.message}`) }
+      )
+  })
+}

--- a/src/client/cli/commands/net/connections.js
+++ b/src/client/cli/commands/net/connections.js
@@ -1,0 +1,29 @@
+// @flow
+
+const RestClient = require('../../../api/RestClient')
+const { subcommand, println } = require('../../util')
+
+module.exports = {
+  command: 'connections',
+  description: `Print a list of all actively connected peers (useful for debugging).\n`,
+  handler: subcommand((opts: {client: RestClient}) => {
+    const {client} = opts
+
+    return client.getNetConnections()
+      .then(
+        addresses => {
+          if (addresses.length < 1) {
+            println(
+              'No active network connections.  Is the node online?'
+            )
+          } else {
+            addresses.forEach(addr => {
+              println(addr)
+            })
+          }
+        })
+      .catch(
+        err => { throw new Error(`Error retrieving network connection list: ${err.message}`) }
+      )
+  })
+}

--- a/src/client/cli/commands/net/identify.js
+++ b/src/client/cli/commands/net/identify.js
@@ -1,0 +1,34 @@
+// @flow
+
+const RestClient = require('../../../api/RestClient')
+const { subcommand, printJSON } = require('../../util')
+
+module.exports = {
+  command: 'identify <peerId>',
+  description: `Use the libp2p-identify protocol to get information about a peer and print in JSON format.\n`,
+  builder: {
+    color: {
+      type: 'boolean',
+      description: 'Explicitly enable (or disable, with --no-color) colorized output.\n',
+      default: null,
+      defaultDescription: 'Print in color if stdout is a tty, and monochrome if piped or pretty-printing is disabled.'
+    },
+    pretty: {
+      type: 'boolean',
+      description: 'Pretty print the output.\n',
+      default: true,
+      defaultDescription: 'True.  Use --no-pretty for compact output.'
+    }
+  },
+  handler: subcommand((opts: {client: RestClient, peerId: string, color: ?boolean, pretty: boolean}) => {
+    const {client, peerId, color, pretty} = opts
+
+    return client.netIdentify(peerId)
+      .then(info => {
+        printJSON(info, {color, pretty})
+      })
+      .catch(
+        err => { throw new Error(`Error retrieving network connection list: ${err.message}`) }
+      )
+  })
+}

--- a/src/client/cli/commands/net/ping.js
+++ b/src/client/cli/commands/net/ping.js
@@ -1,0 +1,20 @@
+// @flow
+
+const RestClient = require('../../../api/RestClient')
+const { subcommand, println } = require('../../util')
+
+module.exports = {
+  command: 'ping <peerId>',
+  describe: 'Ping a remote peer, identified by `peerId`, using the libp2p ping protocol. ' +
+  'Will attempt to lookup the peer with a configured directory server or DHT.\n',
+  handler: subcommand((opts: {peerId: string, client: RestClient}) => {
+    const {peerId, client} = opts
+    println('Pinging peer: ', peerId)
+
+    return client.ping(peerId)
+      .then(
+        success => println('Ping OK'),
+        err => { throw new Error(`Error pinging: ${err.message}`) }
+      )
+  })
+}

--- a/src/client/cli/commands/net/ping.js
+++ b/src/client/cli/commands/net/ping.js
@@ -11,9 +11,9 @@ module.exports = {
     const {peerId, client} = opts
     println('Pinging peer: ', peerId)
 
-    return client.ping(peerId)
+    return client.netPing(peerId)
       .then(
-        success => println('Ping OK'),
+        latency => println(`Ping OK. Latency: ${latency}`),
         err => { throw new Error(`Error pinging: ${err.message}`) }
       )
   })

--- a/src/client/cli/commands/netAddr.js
+++ b/src/client/cli/commands/netAddr.js
@@ -1,34 +1,7 @@
 // @flow
 
-const RestClient = require('../../api/RestClient')
-const { subcommand, println } = require('../util')
-
-module.exports = {
+const cmd = require('./net/addr')
+module.exports = Object.assign({}, cmd, {
   command: 'netAddr [peerId]',
-  describe: `Print the local node's network addresses in multiaddr format. ` +
-    `If 'peerId' is given, prints the locally known addresses for that peer (useful for debugging).\n`,
-  handler: subcommand((opts: {client: RestClient, peerId?: string}) => {
-    const {client, peerId} = opts
-
-    return client.getNetAddresses(peerId)
-      .then(
-        addresses => {
-          if (addresses.length < 1) {
-            if (peerId != null) {
-              println(`No known addresses for peer ${peerId}`)
-            } else {
-              println(
-                'Local node does not have an address. Make sure status is set to "online" or "public"'
-              )
-            }
-          } else {
-            addresses.forEach(addr => {
-              println(addr)
-            })
-          }
-        })
-      .catch(
-        err => { throw new Error(`Error retrieving addresses: ${err.message}`) }
-      )
-  })
-}
+  description: `${cmd.description.trim()} (alias for 'net addr')\n`
+})

--- a/src/client/cli/commands/netConnections.js
+++ b/src/client/cli/commands/netConnections.js
@@ -1,29 +1,7 @@
 // @flow
 
-const RestClient = require('../../api/RestClient')
-const { subcommand, println } = require('../util')
-
-module.exports = {
+const cmd = require('./net/connections')
+module.exports = Object.assign({}, cmd, {
   command: 'netConnections',
-  describe: `Print a list of all actively connected peers (useful for debugging).\n`,
-  handler: subcommand((opts: {client: RestClient}) => {
-    const {client} = opts
-
-    return client.getNetConnections()
-      .then(
-        addresses => {
-          if (addresses.length < 1) {
-            println(
-              'No active network connections.  Is the node online?'
-            )
-          } else {
-            addresses.forEach(addr => {
-              println(addr)
-            })
-          }
-        })
-      .catch(
-        err => { throw new Error(`Error retrieving network connection list: ${err.message}`) }
-      )
-  })
-}
+  description: `${cmd.description.trim()} (alias for 'net connections')\n`
+})

--- a/src/client/cli/commands/ping.js
+++ b/src/client/cli/commands/ping.js
@@ -5,7 +5,7 @@ const { subcommand, println } = require('../util')
 
 module.exports = {
   command: 'ping <peerId>',
-  describe: 'Ping a remote peer, identified by `peerId`. ' +
+  describe: 'Ping a remote peer, identified by `peerId`. Deprecated in favor of `mcclient net ping`.' +
   'Will attempt to lookup the peer with a configured directory server or DHT.\n',
   handler: subcommand((opts: {peerId: string, client: RestClient}) => {
     const {peerId, client} = opts

--- a/src/peer/libp2p_node.js
+++ b/src/peer/libp2p_node.js
@@ -10,6 +10,7 @@ const PeerId = require('peer-id')
 const PeerInfo = require('peer-info')
 const PeerBook = require('peer-book')
 const multiaddr = require('multiaddr')
+const Ping = require('libp2p-ping')
 const mafmt = require('mafmt')
 const Abortable = require('pull-abortable')
 const { promiseTimeout } = require('./util')
@@ -61,6 +62,8 @@ class P2PNode {
     this.swarm.on('peer-mux-closed', (peerInfo) => {
       this.peerBook.removeByB58String(peerInfo.id.toB58String())
     })
+
+    Ping.mount(this.swarm)
 
     this.abortables = new Set()
   }
@@ -226,6 +229,22 @@ class P2PNode {
 
   unhandle (protocol: string): any {
     return this.swarm.unhandle(protocol)
+  }
+
+  ping (peer: PeerInfo): Promise<number> {
+    const pingPromise = new Promise((resolve, reject) => {
+      const p = new Ping(this.swarm, peer)
+      p.on('error', err => {
+        p.stop()
+        reject(err)
+      })
+
+      p.on('ping', latency => {
+        p.stop()
+        resolve(latency)
+      })
+    })
+    return promiseTimeout(this.dialTimeout, pingPromise)
   }
 }
 

--- a/test/ping_test.js
+++ b/test/ping_test.js
@@ -7,11 +7,12 @@ const PeerInfo = require('peer-info')
 const Multiaddr = require('multiaddr')
 
 describe('Ping', function () {
-  let p1, p2, invalidPeer
+  let p1, p2, p3, invalidPeer
 
   before(() => Promise.all([
     makeNode().then(_p1 => { p1 = _p1 }),
     makeNode().then(_p2 => { p2 = _p2 }),
+    makeNode().then(_p3 => { p3 = _p3 }),
     getTestNodeId().then(id => {
       invalidPeer = PeerInfo(id)
       invalidPeer.multiaddr.add(Multiaddr('/ip4/1.2.3.4/tcp/4321'))
@@ -21,7 +22,22 @@ describe('Ping', function () {
   it('pings another node directly by PeerInfo', () => {
     return Promise.all([p1.start(), p2.start()])  // start both peers
       .then(() => p1.ping(p2.peerInfo))
-      .then(result => assert(result))
+      .then(result => assert(result != null))
+  })
+
+  it('uses the libp2p-ping protocol (if possible)', () => {
+    return Promise.all([p1.start(), p2.start()])  // start both peers
+      .then(() => p1.p2p.ping(p2.peerInfo))
+      .then(result => assert.equal(typeof result, 'number', 'libp2p-ping should return latency in ms'))
+  })
+
+  it('falls back to mediachain ping if libp2p-ping fails', () => {
+    p3.p2p.ping = () => Promise.reject(new Error('I only support artisanal, hand-crafted ping protocols!'))
+    return Promise.all([p1.start(), p3.start()])
+      .then(() => p2.ping(p3.peerInfo))
+      .then(result => {
+        assert(result != null)
+      })
   })
 
   it('fails to ping a non-existent node', () => {


### PR DESCRIPTION
This adds mcclient `net ping` and `net identify` commands to support the new endpoints added in https://github.com/mediachain/concat/pull/113

I also moved `netAddr` and `netConnections` to `net addr` and `net connections`, but left the old commands as aliases.

Aleph nodes now support the libp2p-ping protocol, and will try to use it when pinging remote nodes, falling back to the `/mediachain/node/ping` protocol if the libp2p-ping fails.

I didn't add an equivalent of `net identify` to aleph nodes; we should be able to do so without too much fuss if we end up needing it.  We do support the identify protocol as part of the libp2p-swarm setup, so a concat node should be able to get some info from us, although the js implementation of libp2p-identify doesn't populate the `protocols` field, which is a shame.