### PR TITLE
Add test for aleph merge, fix connection bug

### DIFF
--- a/src/client/cli/commands/publish.js
+++ b/src/client/cli/commands/publish.js
@@ -17,6 +17,7 @@ type HandlerOptions = {
   client: RestClient,
   jqFilter: string,
   idFilter: string,
+  prefix: string,
   filename?: string,
   batchSize: number,
   compound?: number,
@@ -225,7 +226,7 @@ function publishStream (opts: {
 
         wki = wki.toString()
 
-        wkiWithPrefix = [ prefix, wki ].join(':')
+        const wkiWithPrefix = [ prefix, wki ].join(':')
 
         const refs = [ wkiWithPrefix ]
         const tags = [] // TODO: support extracting tags

--- a/src/peer/node.js
+++ b/src/peer/node.js
@@ -411,10 +411,11 @@ class MediachainNode {
   }
 
   merge (peer: PeerInfo | PeerId | string, queryString: string): Promise<MergeResult> {
-    return promiseHash({
-      queryStream: this.remoteQueryStream(peer, queryString),
-      dataConn: this.openConnection(peer, PROTOCOLS.node.data)
-    })
+    return this.remoteQueryStream(peer, queryString)
+      .then(queryStream => promiseHash({
+        queryStream,
+        dataConn: this.openConnection(peer, PROTOCOLS.node.data)
+      }))
       .then(({queryStream, dataConn}) => mergeFromStreams(this, queryStream, dataConn))
   }
 

--- a/test/merge_test.js
+++ b/test/merge_test.js
@@ -1,0 +1,77 @@
+// @flow
+
+const assert = require('assert')
+const { before, describe, it } = require('mocha')
+
+const uuid = require('node-uuid')
+
+const { makeNode, mockQueryHandler } = require('./util')
+const { PROTOCOLS } = require('../src/peer/constants')
+const { b58MultihashForBuffer } = require('../src/common/util')
+const { makeSimpleStatement } = require('../src/metadata/statement')
+const serialize = require('../src/metadata/serialize')
+const { generatePublisherId } = require('../src/peer/identity')
+
+import type { PublisherId } from '../src/peer/identity'
+import type { QueryResultMsg, StatementMsg } from '../src/protobuf/types'
+
+const TEST_NAMESPACE = 'scratch.merge-test'
+
+const SEED_OBJECT_BUFFERS = [
+  {id: uuid.v4(), foo: 'bar'},
+  {id: uuid.v4(), test: 'yep'}
+].map(obj => serialize.encode(obj))
+
+function makeSeedStatements (publisherId: PublisherId, seedObjectBuffers: Array<Buffer>): Promise<Array<StatementMsg>> {
+  return Promise.all(
+    seedObjectBuffers.map((buf, idx) => {
+      const object = b58MultihashForBuffer(buf)
+      return makeSimpleStatement(publisherId, TEST_NAMESPACE, {object, refs: [`merge-test:${idx.toString()}`]}, idx)
+    })
+  )
+}
+
+function mockQueryResults (statements: Array<StatementMsg>): Array<QueryResultMsg> {
+  const results: Array<QueryResultMsg> = statements.map(stmt => {
+    return { value: { simple: { stmt } } }
+  })
+
+  return [...results, {end: {}}]
+}
+
+describe('Merge', () => {
+  let alephNode
+  let mockSource
+  let publisherId
+  let seedStatements
+
+  before(() =>
+    makeNode()
+      .then(node => { alephNode = node })
+      .then(() => generatePublisherId())
+      .then(pubId => { publisherId = pubId })
+      .then(() => makeSeedStatements(publisherId, SEED_OBJECT_BUFFERS))
+      .then(statements => { seedStatements = statements })
+      .then(() => makeNode())
+      .then(mockNode => {
+        mockSource = mockNode
+        mockSource.p2p.unhandle(PROTOCOLS.node.query)
+        mockSource.p2p.handle(PROTOCOLS.node.query, mockQueryHandler(mockQueryResults(seedStatements)))
+        return mockNode.putData(...SEED_OBJECT_BUFFERS)
+      })
+  )
+
+  it('adds statements and objects from a remote source', () =>
+    alephNode.start()
+      .then(() => mockSource.start())
+      .then(() => alephNode.merge(mockSource.peerInfo, `SELECT * FROM ${TEST_NAMESPACE}`))
+      .then(result => {
+        console.log('merge result: ', result)
+        assert.notEqual(result, null, 'merge did not return a result')
+      })
+      .catch(err => {
+        console.error('error during merge test: ', err)
+        throw err
+      })
+  )
+})


### PR DESCRIPTION
This add a basic aleph-only test for the merge functionality by mocking the query protocol on an aleph node and merging from it.

I uncovered what looks like a bug in js-libp2p; if you try to open two connections in parallel to the same javascript peer, you get 

```
Uncaught Error: incorrect header check
      at Zlib._handle.onerror (zlib.js:370:17)
```

Changing the connection code in `MediachainNode.merge` from using `Promise.all` to open the streams in parallel to using `.then` to only open the second stream after the first stream is opened makes the error go away... 

I'm not sure what the root cause of the error is; possibly something in the stream multiplexing code.