### PR TITLE
Add `mcclient manifest lookup` command

### DIFF
--- a/src/client/api/RestClient.js
+++ b/src/client/api/RestClient.js
@@ -357,6 +357,12 @@ class RestClient {
       .then(parseBoolResponse)
   }
 
+  listManifestsForEntity (entityId: string): Promise<Array<Object>> {
+    return this.getRequest(`dir/listmf/${entityId}`)
+      .then(r => new NDJsonResponse(r))
+      .then(r => r.values())
+  }
+
   shutdown (): Promise<boolean> {
     return this.postRequest('shutdown', '', false)
       .then(() => true)

--- a/src/client/cli/commands/manifest/lookup.js
+++ b/src/client/cli/commands/manifest/lookup.js
@@ -1,0 +1,21 @@
+// @flow
+
+const RestClient = require('../../../api/RestClient')
+const { subcommand, printJSON } = require('../../util')
+
+module.exports = {
+  command: 'lookup <entityId>',
+  builder: {
+    entityId: {
+      type: 'string',
+      description: 'An "entity" identifier that can be used to verify a public identity. ' +
+        'e.g: "blockstack:mediachainlabs.id" or "keybase:yusef"'
+    }
+  },
+  description: `Query the directory for the manifests belonging to \`entityId\`.\n`,
+  handler: subcommand((opts: {client: RestClient, entityId: string}) => {
+    const {client, entityId} = opts
+    return client.listManifestsForEntity(entityId)
+      .then(m => printJSON(m))
+  })
+}

--- a/src/protobuf/dir.proto
+++ b/src/protobuf/dir.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 package proto;
 
+import "manifest.proto";
+
 message PeerInfo {
   string id = 1;                   // peer id
   repeated bytes addr = 2;         // peer multiaddrs
@@ -15,6 +17,7 @@ message PublisherInfo {
 message RegisterPeer {
   PeerInfo info = 1;
   PublisherInfo publisher = 2;     // optional (v1.4)
+  repeated Manifest manifest = 3;  // optional (v1.5)
 }
 
 // /mediachain/dir/lookup
@@ -41,3 +44,13 @@ message ListNamespacesRequest {}
 message ListNamespacesResponse {
   repeated string namespaces = 1;
 }
+
+// /mediachain/dir/listmf
+message ListManifestRequest {
+  string entity = 1;
+}
+
+message ListManifestResponse {
+  repeated Manifest manifest = 1;
+}
+

--- a/src/protobuf/index.js
+++ b/src/protobuf/index.js
@@ -13,6 +13,10 @@ import type {
   LookupPeerResponseMsg,
   ListPeersRequestMsg,
   ListPeersResponseMsg,
+  ListManifestRequestMsg,
+  ListManifestResponseMsg,
+  ManifestRequestMsg,
+  ManifestResponseMsg,
   PingMsg,
   PongMsg,
   NodeInfoRequestMsg,
@@ -53,11 +57,15 @@ type AllProtos = {
     LookupPeerRequest: ProtoCodec<LookupPeerRequestMsg>,
     LookupPeerResponse: ProtoCodec<LookupPeerResponseMsg>,
     ListPeersRequest: ProtoCodec<ListPeersRequestMsg>,
-    ListPeersResponse: ProtoCodec<ListPeersResponseMsg>
+    ListPeersResponse: ProtoCodec<ListPeersResponseMsg>,
+    ListManifestRequest: ProtoCodec<ListManifestRequestMsg>,
+    ListManifestResponse: ProtoCodec<ListManifestResponseMsg>
   },
   node: {
     Ping: ProtoCodec<PingMsg>,
     Pong: ProtoCodec<PongMsg>,
+    ManifestRequest: ProtoCodec<ManifestRequestMsg>,
+    ManifestResponse: ProtoCodec<ManifestResponseMsg>,
     NodeInfoRequest: ProtoCodec<NodeInfoRequestMsg>,
     NodeInfo: ProtoCodec<NodeInfoMsg>,
     QueryRequest: ProtoCodec<QueryRequestMsg>,
@@ -120,11 +128,15 @@ function loadProtos (): AllProtos {
       LookupPeerRequest: pb.LookupPeerRequest,
       LookupPeerResponse: pb.LookupPeerResponse,
       ListPeersRequest: pb.ListPeersRequest,
-      ListPeersResponse: pb.ListPeersResponse
+      ListPeersResponse: pb.ListPeersResponse,
+      ListManifestRequest: pb.ListManifestRequest,
+      ListManifestResponse: pb.ListManifestResponse
     },
     node: {
       Ping: pb.Ping,
       Pong: pb.Pong,
+      ManifestRequest: pb.ManifestRequest,
+      ManifestResponse: pb.ManifestResponse,
       NodeInfoRequest: pb.NodeInfoRequest,
       NodeInfo: pb.NodeInfo,
       QueryRequest: pb.QueryRequest,

--- a/src/protobuf/node.proto
+++ b/src/protobuf/node.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package proto;
 
 import "stmt.proto";
+import "manifest.proto";
 
 // end of result stream marker
 message StreamEnd {}
@@ -18,6 +19,13 @@ message NodeInfo {
   string peer = 1;
   string publisher = 2;
   string info = 3;
+}
+
+// /mediachain/node/manifest
+message ManifestRequest {}
+
+message ManifestResponse {
+  repeated Manifest manifest = 1;
 }
 
 // /mediachain/node/ping

--- a/src/protobuf/types.js
+++ b/src/protobuf/types.js
@@ -14,7 +14,8 @@ export type PublisherInfoMsg = {
 
 export type RegisterPeerMsg = {
   info: PeerInfoMsg,
-  publisher?: PublisherInfoMsg
+  publisher?: PublisherInfoMsg,
+  manifest?: Array<ManifestMsg>
 }
 
 export type LookupPeerRequestMsg = {
@@ -33,7 +34,21 @@ export type ListPeersResponseMsg = {
   peers: Array<string>
 }
 
+export type ListManifestRequestMsg = {
+  entity: string
+}
+
+export type ListManifestResponseMsg = {
+  manifest: Array<ManifestMsg>
+}
+
 // node.proto
+
+export type ManifestRequestMsg = {}
+
+export type ManifestResponseMsg = {
+  manifest: Array<ManifestMsg>
+}
 
 export type PingMsg = { }
 export type PongMsg = { }


### PR DESCRIPTION
This adds a command for the `/dir/listmf/:entityId` API endpoint added in https://github.com/mediachain/concat/pull/125

`mcclient manifest list blockstack:vyzobot.id` should give you this if you're running `mcnode` from master: 

```
[
  {
    "entity": "blockstack:vyzobot.id",
    "keyId": "Qmcvnd3Jn41DwSjaZcVXpTpX873czeSAAf3PcyyULdvFZc",
    "body": {
      "node": {
        "peer": "QmeiY2eHMwK92Zt6X4kUUC3MsjMmVb2VnGZ17DhnhRPCEQ",
        "publisher": "4XTTM4K8sqTb7xYviJJcRDJ5W6TpQxMoJ7GtBstTALgh5wzGm"
      }
    },
    "timestamp": "1485367315",
    "signature": "KB9tExh+kUNuAEhlm0qXhgSIAhYWP+zABnVR3pRk+cUFFsAO0rOknm3sO+zP2n+ysDvS88JiZbeuENhdzEcHBQ=="
  },
  {
    "entity": "blockstack:vyzobot.id",
    "keyId": "Qmcvnd3Jn41DwSjaZcVXpTpX873czeSAAf3PcyyULdvFZc",
    "body": {
      "node": {
        "peer": "QmZ6dckUhRouVr6AsBTpK6vMLVpcz1KAeJAJVQEZQ5gCek",
        "publisher": "4XTTM2kxMrVAZXSAu9AKtHBiMFpiqWToAmr7s6BzGXiPoriHy"
      }
    },
    "timestamp": "1485367604",
    "signature": "AO0NyB6wW5PL/dVj1XNWEYyq7YOVgin04md08HwbN7HogBKzKPm6pApdWS2TSCa/l/2sG4Pg8M+tQXqPfttVAw=="
  }
]

```