### PR TITLE
Define separate SignedStatement & UnsignedStatement classes

### DIFF
--- a/integration-test/push_test.js
+++ b/integration-test/push_test.js
@@ -10,7 +10,7 @@ const { getTestNodeId } = require('../test/util')
 const { MediachainNode: AlephNode } = require('../src/peer/node')
 const { concatNodeClient, concatNodePeerInfo } = require('./util')
 const { PublisherId } = require('../src/peer/identity')
-const { Statement } = require('../src/model/statement')
+const { SignedStatement } = require('../src/model/statement')
 
 const TEST_NAMESPACE = 'scratch.push-test'
 const UNAUTHORIZED_NAMESPACE = 'scratch.unauthorized-push-test'
@@ -38,14 +38,14 @@ function preparePartiallyValidStatements (alephNode: AlephNode, numValid: number
     .then(([object]) => {
       const promises = []
       for (let i = 0; i < numValid; i++) {
-        promises.push(Statement.createSimple(alephNode.publisherId, TEST_NAMESPACE, {
+        promises.push(SignedStatement.createSimple(alephNode.publisherId, TEST_NAMESPACE, {
           object,
           refs: [`test:${i.toString()}`]
         },
         alephNode.statementCounter))
       }
       // add a statement with an invalid object reference
-      promises.push(Statement.createSimple(alephNode.publisherId, TEST_NAMESPACE, {
+      promises.push(SignedStatement.createSimple(alephNode.publisherId, TEST_NAMESPACE, {
         object: 'QmNLftPEMzsadpbTsGaVP3haETYJb4GfnCgQiaFj5Red9G', refs: [], deps: [], tags: []
       }))
       return Promise.all(promises)

--- a/src/peer/node.js
+++ b/src/peer/node.js
@@ -23,7 +23,7 @@ const {
 const { promiseHash, isB58Multihash } = require('../common/util')
 const { pushStatementsToConn } = require('./push')
 const { mergeFromStreams } = require('./merge')
-const { Statement } = require('../model/statement')
+const { Statement, SignedStatement } = require('../model/statement')
 const { unpackQueryResultProtobuf } = require('../model/query_result')
 
 import type { QueryResult, QueryResultValue } from '../model/query_result'
@@ -439,7 +439,7 @@ class MediachainNode {
     return this.putData(object)
       .then(([objectHash]) => {
         const body = {object: objectHash, refs, deps, tags}
-        return Statement.createSimple(publisherId, namespace, body, this.statementCounter)
+        return SignedStatement.createSimple(publisherId, namespace, body, this.statementCounter)
       })
       .then(stmt => this.db.put(stmt)
         .then(() => stmt.id))

--- a/src/protobuf/types.js
+++ b/src/protobuf/types.js
@@ -155,7 +155,7 @@ export type StatementMsg = {
   namespace: string,
   body: StatementBodyMsg,
   timestamp: number,
-  signature: Buffer,
+  signature?: Buffer,
 };
 
 // manifest.proto

--- a/test/model/statement_test.js
+++ b/test/model/statement_test.js
@@ -5,7 +5,7 @@ chai.use(require('chai-as-promised'))
 const { expect } = chai
 const { describe, it, before } = require('mocha')
 const { PublisherId, PrivateSigningKey } = require('../../src/peer/identity')
-const { Statement, StatementBody, SimpleStatementBody, ExpandedSimpleStatementBody, CompoundStatementBody, EnvelopeStatementBody } = require('../../src/model/statement')
+const { Statement, SignedStatement, StatementBody, SimpleStatementBody, ExpandedSimpleStatementBody, CompoundStatementBody, EnvelopeStatementBody } = require('../../src/model/statement')
 const pb = require('../../src/protobuf')
 const { setEquals, stringifyNestedBuffers } = require('../../src/common/util')
 const { inspect } = require('util')
@@ -74,7 +74,7 @@ describe('Statements', () => {
 
   describe('constructor', () => {
     it('accepts base64-encoded signatures', () => {
-      const stmt = new Statement({
+      const stmt = new SignedStatement({
         id: 'foo',
         publisher: 'bar',
         namespace: 'baz',
@@ -87,26 +87,26 @@ describe('Statements', () => {
     })
   })
 
-  describe('Statement.create()', () => {
+  describe('SignedStatement.create()', () => {
     it('accepts a StatementBody object or StatementBodyMsg protobuf object', () => {
       const body = new SimpleStatementBody({object: 'foo'})
       let stmt1, stmt2
-      return Statement.create(publisherIds.simple, 'test.foo', body)
+      return SignedStatement.create(publisherIds.simple, 'test.foo', body)
         .then(s => { stmt1 = s })
-        .then(() => Statement.create(publisherIds.simple, 'test.create', body.toProtobuf()))
+        .then(() => SignedStatement.create(publisherIds.simple, 'test.create', body.toProtobuf()))
         .then(s => { stmt2 = s })
         .then(() => {
-          expect(stmt1).to.be.an.instanceof(Statement)
-          expect(stmt2).to.be.an.instanceof(Statement)
+          expect(stmt1).to.be.an.instanceof(SignedStatement)
+          expect(stmt2).to.be.an.instanceof(SignedStatement)
           expect(stmt1.toProtobuf().body).to.deep.eql(stmt2.toProtobuf().body)
         })
     })
   })
 
-  describe('Statement.createSimple()', () => {
+  describe('SignedStatement.createSimple()', () => {
     it('accepts an object reference string', () => {
       const object = 'QmREZU7Pqv3ezGWnXQiHXCm2uipjdHkuXWRygx5gMt4Bwq'
-      return Statement.createSimple(publisherIds.simple, 'test.createSimple', {object})
+      return SignedStatement.createSimple(publisherIds.simple, 'test.createSimple', {object})
         .then(stmt => {
           expect(stmt).to.be.an.instanceof(Statement)
           expect(stmt.body).to.be.an.instanceof(SimpleStatementBody)
@@ -117,7 +117,7 @@ describe('Statements', () => {
     it('accepts a JS object to create an statement with expanded body', () => {
       const object = {foo: 'bar'}
       const objectHash = 'QmREZU7Pqv3ezGWnXQiHXCm2uipjdHkuXWRygx5gMt4Bwq'
-      return Statement.createSimple(publisherIds.simple, 'test.createSimple.expandedBody', {object})
+      return SignedStatement.createSimple(publisherIds.simple, 'test.createSimple.expandedBody', {object})
         .then(stmt => {
           expect(stmt).to.be.an.instanceof(Statement)
           expect(stmt.objectIds).to.contain(objectHash)
@@ -127,7 +127,7 @@ describe('Statements', () => {
     })
   })
 
-  describe('Statement.sign()', () => {
+  describe('UnsignedStatement.sign()', () => {
     it('produces a correct signature when signed by the publishers key', () => {
       const promises = []
 
@@ -137,14 +137,14 @@ describe('Statements', () => {
         const publicKey = publisherId.privateKey.publicKey
 
         for (const stmtMsg of statements) {
-          const stmt = Statement.fromProtobuf(stmtMsg)
+          const stmt = SignedStatement.fromProtobuf(stmtMsg)
           const promise = stmt.verifySignature(publicKey)
             .then(() => {
-              const originalSig = stmt.signature
-              stmt.signature = Buffer.from('foo')
-              return stmt.sign(publisherId)
+              const unsigned = stmt.asUnsignedStatement()
+              return unsigned.sign(publisherId)
                 .then(signedStmt => {
-                  expect(signedStmt.signature).to.deep.eql(originalSig)
+                  expect(signedStmt).to.be.an.instanceof(SignedStatement)
+                  expect(signedStmt.signature).to.deep.eql(stmt.signature)
                 })
             })
           promises.push(promise)
@@ -155,7 +155,7 @@ describe('Statements', () => {
     })
 
     it('fails when signing with a PublisherId that does not match the statement', () => {
-      const stmt = Statement.fromProtobuf(fixtures.statements.simple[0])
+      const stmt = Statement.fromProtobuf(fixtures.statements.simple[0]).asUnsignedStatement()
       return expect(stmt.sign(publisherIds.compound))
         .to.eventually.be.rejectedWith('publisher id of signer does not match statement publisher')
     })

--- a/test/peer/merge_test.js
+++ b/test/peer/merge_test.js
@@ -8,7 +8,7 @@ const uuid = require('uuid')
 const { makeNode, mockQueryHandler } = require('../util')
 const { PROTOCOLS } = require('../../src/peer/constants')
 const { b58MultihashForBuffer } = require('../../src/common/util')
-const { Statement } = require('../../src/model/statement')
+const { Statement, SignedStatement } = require('../../src/model/statement')
 const serialize = require('../../src/metadata/serialize')
 const { PublisherId } = require('../../src/peer/identity')
 
@@ -25,7 +25,7 @@ function makeSeedStatements (publisherId: PublisherId, seedObjectBuffers: Array<
   return Promise.all(
     seedObjectBuffers.map((buf, idx) => {
       const object = b58MultihashForBuffer(buf)
-      return Statement.createSimple(publisherId, TEST_NAMESPACE, {object, refs: [`merge-test:${idx.toString()}`]}, idx)
+      return SignedStatement.createSimple(publisherId, TEST_NAMESPACE, {object, refs: [`merge-test:${idx.toString()}`]}, idx)
     })
   )
 }

--- a/test/peer/push_test.js
+++ b/test/peer/push_test.js
@@ -11,7 +11,7 @@ const uuid = require('uuid')
 const { makeNode, mockPushHandler } = require('../util')
 const { PROTOCOLS } = require('../../src/peer/constants')
 const { b58MultihashForBuffer } = require('../../src/common/util')
-const { Statement } = require('../../src/model/statement')
+const { Statement, SignedStatement } = require('../../src/model/statement')
 const serialize = require('../../src/metadata/serialize')
 const { PublisherId } = require('../../src/peer/identity')
 
@@ -25,7 +25,7 @@ function makeSeedStatements (publisherId: PublisherId, seedObjectBuffers: Array<
   return Promise.all(
     seedObjectBuffers.map((buf, idx) => {
       const object = b58MultihashForBuffer(buf)
-      return Statement.createSimple(publisherId, TEST_NAMESPACE, {object, refs: [`merge-test:${idx.toString()}`]}, idx)
+      return SignedStatement.createSimple(publisherId, TEST_NAMESPACE, {object, refs: [`merge-test:${idx.toString()}`]}, idx)
     })
   )
 }


### PR DESCRIPTION
This refactors the Statement class hierarchy a bit to make a clean split between signed and unsigned statements.

There's now a base `Statement` class that has everything except the `signature` field, plus common helper methods like `.toProtobuf`, `.expandObjects`, etc.

The `UnsignedStatement` subclass adds the `.calculateSignature` and `.sign` methods, which return `Buffer` and `SignedStatement`, respectively.

The `SignedStatement` class has the `signature` field and the `.verifySignature` method.  Both `SignedStatement` and `UnsignedStatement` inherit from `Statement` directly, so `SignedStatement` does not have the `.sign` and `.calculateSignature` methods.  However, there's a helper on the the base class `.asUnsignedStatement()` that will return an unsigned copy of either a signed or unsigned statement.  So, if you need to strip an existing signature and re-sign a message, you can do:

```javascript
mySignedStmt.asUnsignedStatement().sign(newPublisherId)
  .then(signed => {
    // `signed` has a new signature
  })
```

Converting from protobuf still happens with `Statement.fromProtobuf()`, which will return a `SignedStatement` if the protobuf message has a `signature`, and an `UnsignedStatement` otherwise.
