### PR TITLE
Remove dependency on multihashing module

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,9 +9,9 @@
       "optional": true
     },
     "@types/node": {
-      "version": "6.0.61",
+      "version": "6.0.63",
       "from": "@types/node@>=6.0.45 <7.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.61.tgz"
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.63.tgz"
     },
     "abstract-leveldown": {
       "version": "2.4.1",
@@ -86,12 +86,12 @@
     },
     "asn1.js": {
       "version": "4.9.1",
-      "from": "asn1.js@>=4.8.1 <5.0.0",
+      "from": "asn1.js@>=4.9.1 <5.0.0",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz"
     },
     "async": {
       "version": "2.1.4",
-      "from": "async@>=2.1.2 <3.0.0",
+      "from": "async@>=2.1.4 <3.0.0",
       "resolved": "https://registry.npmjs.org/async/-/async-2.1.4.tgz"
     },
     "async-each-series": {
@@ -110,9 +110,9 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
     },
     "base-x": {
-      "version": "1.1.0",
-      "from": "base-x@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-1.1.0.tgz"
+      "version": "2.0.4",
+      "from": "base-x@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-2.0.4.tgz"
     },
     "beeper": {
       "version": "1.1.1",
@@ -145,9 +145,9 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz"
     },
     "borc": {
-      "version": "2.0.1",
+      "version": "2.0.2",
       "from": "borc@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/borc/-/borc-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/borc/-/borc-2.0.2.tgz",
       "dependencies": {
         "commander": {
           "version": "2.9.0",
@@ -178,35 +178,10 @@
         }
       }
     },
-    "brorand": {
-      "version": "1.0.6",
-      "from": "brorand@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.0.6.tgz"
-    },
     "browserify-aes": {
       "version": "1.0.6",
       "from": "browserify-aes@>=1.0.6 <2.0.0",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz"
-    },
-    "browserify-cipher": {
-      "version": "1.0.0",
-      "from": "browserify-cipher@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz"
-    },
-    "browserify-des": {
-      "version": "1.0.0",
-      "from": "browserify-des@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz"
-    },
-    "browserify-rsa": {
-      "version": "4.0.1",
-      "from": "browserify-rsa@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz"
-    },
-    "browserify-sign": {
-      "version": "4.0.0",
-      "from": "browserify-sign@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.0.tgz"
     },
     "browserify-zlib-next": {
       "version": "1.0.1",
@@ -214,9 +189,9 @@
       "resolved": "https://registry.npmjs.org/browserify-zlib-next/-/browserify-zlib-next-1.0.1.tgz"
     },
     "bs58": {
-      "version": "3.1.0",
-      "from": "bs58@>=3.1.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-3.1.0.tgz"
+      "version": "4.0.0",
+      "from": "bs58@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.0.tgz"
     },
     "buffer-crc32": {
       "version": "0.2.13",
@@ -347,11 +322,6 @@
       "from": "core-util-is@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
     },
-    "create-ecdh": {
-      "version": "4.0.0",
-      "from": "create-ecdh@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz"
-    },
     "create-error-class": {
       "version": "3.0.2",
       "from": "create-error-class@>=3.0.1 <4.0.0",
@@ -361,16 +331,6 @@
       "version": "1.1.2",
       "from": "create-hash@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz"
-    },
-    "create-hmac": {
-      "version": "1.1.4",
-      "from": "create-hmac@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz"
-    },
-    "crypto-browserify": {
-      "version": "3.11.0",
-      "from": "crypto-browserify@>=3.10.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz"
     },
     "dateformat": {
       "version": "2.0.0",
@@ -470,20 +430,10 @@
       "from": "delimit-stream@0.1.0",
       "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz"
     },
-    "des.js": {
-      "version": "1.0.0",
-      "from": "des.js@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz"
-    },
     "detect-file": {
       "version": "0.1.0",
       "from": "detect-file@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz"
-    },
-    "diffie-hellman": {
-      "version": "5.0.2",
-      "from": "diffie-hellman@>=5.0.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz"
     },
     "digest-stream": {
       "version": "1.0.1",
@@ -528,11 +478,6 @@
       "version": "1.1.1",
       "from": "each-async@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz"
-    },
-    "elliptic": {
-      "version": "6.3.2",
-      "from": "elliptic@>=6.0.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.2.tgz"
     },
     "encoding": {
       "version": "0.1.12",
@@ -922,20 +867,15 @@
       "from": "has-gulplog@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz"
     },
-    "hash.js": {
-      "version": "1.0.3",
-      "from": "hash.js@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
-    },
     "homedir-polyfill": {
       "version": "1.0.1",
       "from": "homedir-polyfill@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz"
     },
     "hosted-git-info": {
-      "version": "2.1.5",
+      "version": "2.2.0",
       "from": "hosted-git-info@>=2.1.4 <3.0.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz"
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.2.0.tgz"
     },
     "hpack.js": {
       "version": "2.1.6",
@@ -973,9 +913,9 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
     },
     "interface-connection": {
-      "version": "0.3.0",
+      "version": "0.3.1",
       "from": "interface-connection@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/interface-connection/-/interface-connection-0.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/interface-connection/-/interface-connection-0.3.1.tgz"
     },
     "interpret": {
       "version": "0.6.6",
@@ -1164,7 +1104,7 @@
     },
     "js-sha3": {
       "version": "0.5.7",
-      "from": "js-sha3@>=0.5.5 <0.6.0",
+      "from": "js-sha3@>=0.5.7 <0.6.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz"
     },
     "jsbn": {
@@ -1194,7 +1134,7 @@
     },
     "keypair": {
       "version": "1.0.1",
-      "from": "keypair@>=1.0.0 <2.0.0",
+      "from": "keypair@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/keypair/-/keypair-1.0.1.tgz"
     },
     "kind-of": {
@@ -1272,24 +1212,50 @@
       "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.3.tgz"
     },
     "libp2p-crypto": {
-      "version": "0.7.6",
-      "from": "libp2p-crypto@>=0.7.6 <0.8.0",
-      "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.7.6.tgz"
+      "version": "0.8.1",
+      "from": "libp2p-crypto@>=0.8.0 <0.9.0",
+      "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.8.1.tgz"
     },
     "libp2p-identify": {
-      "version": "0.3.1",
+      "version": "0.3.2",
       "from": "libp2p-identify@>=0.3.1 <0.4.0",
-      "resolved": "https://registry.npmjs.org/libp2p-identify/-/libp2p-identify-0.3.1.tgz"
+      "resolved": "https://registry.npmjs.org/libp2p-identify/-/libp2p-identify-0.3.2.tgz"
     },
     "libp2p-ping": {
       "version": "0.3.0",
       "from": "libp2p-ping@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/libp2p-ping/-/libp2p-ping-0.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/libp2p-ping/-/libp2p-ping-0.3.0.tgz",
+      "dependencies": {
+        "libp2p-crypto": {
+          "version": "0.7.7",
+          "from": "libp2p-crypto@>=0.7.3 <0.8.0",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.7.7.tgz"
+        }
+      }
     },
     "libp2p-secio": {
       "version": "0.6.5",
       "from": "libp2p-secio@>=0.6.4 <0.7.0",
-      "resolved": "https://registry.npmjs.org/libp2p-secio/-/libp2p-secio-0.6.5.tgz"
+      "resolved": "https://registry.npmjs.org/libp2p-secio/-/libp2p-secio-0.6.5.tgz",
+      "dependencies": {
+        "libp2p-crypto": {
+          "version": "0.7.7",
+          "from": "libp2p-crypto@>=0.7.6 <0.8.0",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.7.7.tgz",
+          "dependencies": {
+            "multihashing-async": {
+              "version": "0.4.2",
+              "from": "multihashing-async@^0.4.0",
+              "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.2.tgz"
+            }
+          }
+        },
+        "multihashing-async": {
+          "version": "0.3.0",
+          "from": "multihashing-async@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.3.0.tgz"
+        }
+      }
     },
     "libp2p-spdy": {
       "version": "0.10.3",
@@ -1297,9 +1263,9 @@
       "resolved": "https://registry.npmjs.org/libp2p-spdy/-/libp2p-spdy-0.10.3.tgz"
     },
     "libp2p-swarm": {
-      "version": "0.26.12",
+      "version": "0.26.14",
       "from": "libp2p-swarm@>=0.26.2 <0.27.0",
-      "resolved": "https://registry.npmjs.org/libp2p-swarm/-/libp2p-swarm-0.26.12.tgz",
+      "resolved": "https://registry.npmjs.org/libp2p-swarm/-/libp2p-swarm-0.26.14.tgz",
       "dependencies": {
         "once": {
           "version": "1.4.0",
@@ -1309,14 +1275,14 @@
       }
     },
     "libp2p-tcp": {
-      "version": "0.9.1",
+      "version": "0.9.3",
       "from": "libp2p-tcp@>=0.9.1 <0.10.0",
-      "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.9.1.tgz"
+      "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.9.3.tgz"
     },
     "libp2p-websockets": {
-      "version": "0.9.1",
+      "version": "0.9.2",
       "from": "libp2p-websockets@>=0.9.1 <0.10.0",
-      "resolved": "https://registry.npmjs.org/libp2p-websockets/-/libp2p-websockets-0.9.1.tgz"
+      "resolved": "https://registry.npmjs.org/libp2p-websockets/-/libp2p-websockets-0.9.2.tgz"
     },
     "liftoff": {
       "version": "2.2.5",
@@ -1338,42 +1304,10 @@
       "from": "lodash@>=4.17.1 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
     },
-    "lodash._basebind": {
-      "version": "2.4.1",
-      "from": "lodash._basebind@>=2.4.1 <2.5.0",
-      "resolved": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.4.1.tgz"
-    },
     "lodash._basecopy": {
       "version": "3.0.1",
       "from": "lodash._basecopy@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
-    },
-    "lodash._basecreate": {
-      "version": "2.4.1",
-      "from": "lodash._basecreate@>=2.4.1 <2.5.0",
-      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
-      "dependencies": {
-        "lodash.noop": {
-          "version": "2.4.1",
-          "from": "lodash.noop@>=2.4.1 <2.5.0",
-          "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
-        }
-      }
-    },
-    "lodash._basecreatecallback": {
-      "version": "2.4.1",
-      "from": "lodash._basecreatecallback@>=2.4.1 <2.5.0",
-      "resolved": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.4.1.tgz"
-    },
-    "lodash._basecreatewrapper": {
-      "version": "2.4.1",
-      "from": "lodash._basecreatewrapper@>=2.4.1 <2.5.0",
-      "resolved": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.4.1.tgz"
-    },
-    "lodash._baseindexof": {
-      "version": "2.4.1",
-      "from": "lodash._baseindexof@>=2.4.1 <2.5.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-2.4.1.tgz"
     },
     "lodash._basetostring": {
       "version": "3.0.1",
@@ -1385,18 +1319,6 @@
       "from": "lodash._basevalues@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
     },
-    "lodash._createwrapper": {
-      "version": "2.4.1",
-      "from": "lodash._createwrapper@>=2.4.1 <2.5.0",
-      "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.4.1.tgz",
-      "dependencies": {
-        "lodash.isfunction": {
-          "version": "2.4.1",
-          "from": "lodash.isfunction@>=2.4.1 <2.5.0",
-          "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz"
-        }
-      }
-    },
     "lodash._getnative": {
       "version": "3.9.1",
       "from": "lodash._getnative@>=3.0.0 <4.0.0",
@@ -1406,16 +1328,6 @@
       "version": "3.0.9",
       "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
-    },
-    "lodash._isnative": {
-      "version": "2.4.1",
-      "from": "lodash._isnative@>=2.4.1 <2.5.0",
-      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
-    },
-    "lodash._objecttypes": {
-      "version": "2.4.1",
-      "from": "lodash._objecttypes@>=2.4.1 <2.5.0",
-      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
     },
     "lodash._reescape": {
       "version": "3.0.0",
@@ -1437,45 +1349,6 @@
       "from": "lodash._root@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
     },
-    "lodash._setbinddata": {
-      "version": "2.4.1",
-      "from": "lodash._setbinddata@>=2.4.1 <2.5.0",
-      "resolved": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz",
-      "dependencies": {
-        "lodash.noop": {
-          "version": "2.4.1",
-          "from": "lodash.noop@>=2.4.1 <2.5.0",
-          "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
-        }
-      }
-    },
-    "lodash._shimkeys": {
-      "version": "2.4.1",
-      "from": "lodash._shimkeys@>=2.4.1 <2.5.0",
-      "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz"
-    },
-    "lodash._slice": {
-      "version": "2.4.1",
-      "from": "lodash._slice@>=2.4.1 <2.5.0",
-      "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.4.1.tgz"
-    },
-    "lodash.bind": {
-      "version": "2.4.1",
-      "from": "lodash.bind@>=2.4.1 <2.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.4.1.tgz"
-    },
-    "lodash.contains": {
-      "version": "2.4.3",
-      "from": "lodash.contains@>=2.4.3 <3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.contains/-/lodash.contains-2.4.3.tgz",
-      "dependencies": {
-        "lodash.isarray": {
-          "version": "2.4.1",
-          "from": "lodash.isarray@>=2.4.1 <2.5.0",
-          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-2.4.1.tgz"
-        }
-      }
-    },
     "lodash.defaults": {
       "version": "4.2.0",
       "from": "lodash.defaults@>=4.1.0 <5.0.0",
@@ -1495,23 +1368,6 @@
       "version": "4.6.0",
       "from": "lodash.find@>=4.6.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz"
-    },
-    "lodash.forown": {
-      "version": "2.4.1",
-      "from": "lodash.forown@>=2.4.1 <2.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.forown/-/lodash.forown-2.4.1.tgz",
-      "dependencies": {
-        "lodash.keys": {
-          "version": "2.4.1",
-          "from": "lodash.keys@>=2.4.1 <2.5.0",
-          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz"
-        }
-      }
-    },
-    "lodash.identity": {
-      "version": "2.4.1",
-      "from": "lodash.identity@>=2.4.1 <2.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.4.1.tgz"
     },
     "lodash.includes": {
       "version": "4.3.0",
@@ -1537,16 +1393,6 @@
       "version": "3.0.8",
       "from": "lodash.isfunction@>=3.0.8 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.8.tgz"
-    },
-    "lodash.isobject": {
-      "version": "2.4.1",
-      "from": "lodash.isobject@>=2.4.1 <2.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz"
-    },
-    "lodash.isstring": {
-      "version": "2.4.1",
-      "from": "lodash.isstring@>=2.4.1 <2.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-2.4.1.tgz"
     },
     "lodash.keys": {
       "version": "3.1.2",
@@ -1592,11 +1438,6 @@
       "version": "3.6.1",
       "from": "lodash.restparam@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
-    },
-    "lodash.support": {
-      "version": "2.4.1",
-      "from": "lodash.support@>=2.4.1 <2.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.4.1.tgz"
     },
     "lodash.template": {
       "version": "3.6.2",
@@ -1665,11 +1506,6 @@
         }
       }
     },
-    "miller-rabin": {
-      "version": "4.0.0",
-      "from": "miller-rabin@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz"
-    },
     "minimalistic-assert": {
       "version": "1.0.0",
       "from": "minimalistic-assert@>=1.0.0 <2.0.0",
@@ -1703,43 +1539,19 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
     },
     "multiaddr": {
-      "version": "2.2.0",
+      "version": "2.2.1",
       "from": "multiaddr@>=2.1.3 <3.0.0",
-      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-2.2.0.tgz",
-      "dependencies": {
-        "base-x": {
-          "version": "2.0.3",
-          "from": "base-x@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/base-x/-/base-x-2.0.3.tgz"
-        },
-        "bs58": {
-          "version": "4.0.0",
-          "from": "bs58@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.0.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-2.2.1.tgz"
     },
     "multihashes": {
-      "version": "0.3.1",
+      "version": "0.3.3",
       "from": "multihashes@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.3.1.tgz"
-    },
-    "multihashing": {
-      "version": "0.2.1",
-      "from": "multihashing@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/multihashing/-/multihashing-0.2.1.tgz",
-      "dependencies": {
-        "multihashes": {
-          "version": "0.2.2",
-          "from": "multihashes@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.2.2.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.3.3.tgz"
     },
     "multihashing-async": {
-      "version": "0.3.0",
-      "from": "multihashing-async@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.3.0.tgz"
+      "version": "0.4.2",
+      "from": "multihashing-async@>=0.4.2 <0.5.0",
+      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.2.tgz"
     },
     "multipipe": {
       "version": "0.1.2",
@@ -1764,9 +1576,9 @@
       }
     },
     "multistream-select": {
-      "version": "0.13.2",
-      "from": "multistream-select@>=0.13.2 <0.14.0",
-      "resolved": "https://registry.npmjs.org/multistream-select/-/multistream-select-0.13.2.tgz",
+      "version": "0.13.4",
+      "from": "multistream-select@>=0.13.3 <0.14.0",
+      "resolved": "https://registry.npmjs.org/multistream-select/-/multistream-select-0.13.4.tgz",
       "dependencies": {
         "once": {
           "version": "1.4.0",
@@ -1779,6 +1591,11 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
         }
       }
+    },
+    "murmurhash3js": {
+      "version": "3.0.1",
+      "from": "murmurhash3js@>=3.0.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash3js/-/murmurhash3js-3.0.1.tgz"
     },
     "nan": {
       "version": "2.5.1",
@@ -1809,9 +1626,9 @@
       "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz"
     },
     "node-webcrypto-ossl": {
-      "version": "1.0.16",
-      "from": "node-webcrypto-ossl@>=1.0.15 <2.0.0",
-      "resolved": "https://registry.npmjs.org/node-webcrypto-ossl/-/node-webcrypto-ossl-1.0.16.tgz",
+      "version": "1.0.17",
+      "from": "node-webcrypto-ossl@>=1.0.17 <2.0.0",
+      "resolved": "https://registry.npmjs.org/node-webcrypto-ossl/-/node-webcrypto-ossl-1.0.17.tgz",
       "optional": true
     },
     "nodeify": {
@@ -1904,11 +1721,6 @@
       "from": "pako@>=1.0.4 <1.1.0",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.4.tgz"
     },
-    "parse-asn1": {
-      "version": "5.0.0",
-      "from": "parse-asn1@>=5.0.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.0.0.tgz"
-    },
     "parse-glob": {
       "version": "3.0.4",
       "from": "parse-glob@>=3.0.4 <4.0.0",
@@ -1968,25 +1780,20 @@
       "from": "path-type@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
     },
-    "pbkdf2": {
-      "version": "3.0.9",
-      "from": "pbkdf2@>=3.0.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.9.tgz"
-    },
     "peer-book": {
-      "version": "0.3.0",
+      "version": "0.3.1",
       "from": "peer-book@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/peer-book/-/peer-book-0.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/peer-book/-/peer-book-0.3.1.tgz"
     },
     "peer-id": {
-      "version": "0.8.1",
+      "version": "0.8.2",
       "from": "peer-id@>=0.8.0 <0.9.0",
-      "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.8.1.tgz"
+      "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.8.2.tgz"
     },
     "peer-info": {
-      "version": "0.8.2",
+      "version": "0.8.3",
       "from": "peer-info@>=0.8.0 <0.9.0",
-      "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.8.2.tgz"
+      "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.8.3.tgz"
     },
     "pem-jwk": {
       "version": "1.5.1",
@@ -2065,11 +1872,6 @@
       "version": "1.0.1",
       "from": "prr@>=1.0.1 <1.1.0",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz"
-    },
-    "public-encrypt": {
-      "version": "4.0.0",
-      "from": "public-encrypt@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz"
     },
     "pull-abortable": {
       "version": "4.1.0",
@@ -2171,11 +1973,6 @@
       "version": "1.1.6",
       "from": "randomatic@>=1.1.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz"
-    },
-    "randombytes": {
-      "version": "2.0.3",
-      "from": "randombytes@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.3.tgz"
     },
     "rc": {
       "version": "1.1.6",
@@ -3454,6 +3251,12 @@
       "from": "trim-repeated@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz"
     },
+    "tslib": {
+      "version": "1.5.0",
+      "from": "tslib@>=1.5.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.5.0.tgz",
+      "optional": true
+    },
     "tunnel-agent": {
       "version": "0.4.3",
       "from": "tunnel-agent@>=0.4.0 <0.5.0",
@@ -3487,9 +3290,9 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
     },
     "typescript": {
-      "version": "2.1.5",
+      "version": "2.1.6",
       "from": "typescript@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.1.6.tgz",
       "optional": true
     },
     "ultron": {
@@ -3596,15 +3399,10 @@
       "from": "wbuf@>=1.4.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.2.tgz"
     },
-    "webcrypto": {
-      "version": "0.1.0",
-      "from": "webcrypto@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/webcrypto/-/webcrypto-0.1.0.tgz"
-    },
     "webcrypto-core": {
-      "version": "0.1.7",
+      "version": "0.1.10",
       "from": "webcrypto-core@>=0.0.0 <1.0.0",
-      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-0.1.10.tgz",
       "optional": true
     },
     "webcrypto-shim": {

--- a/package.json
+++ b/package.json
@@ -52,10 +52,8 @@
     "mkdirp": "^0.5.1",
     "multiaddr": "^2.1.3",
     "multihashes": "^0.3.0",
-    "multihashing": "^0.2.1",
     "ndjson": "^1.4.3",
     "node-fetch": "^1.6.3",
-    "uuid": "^3.0.1",
     "peer-book": "^0.3.0",
     "peer-id": "^0.8.0",
     "peer-info": "^0.8.0",
@@ -71,6 +69,7 @@
     "temp": "^0.8.3",
     "thenify-all": "^1.6.0",
     "tunnel-ssh": "^4.1.1",
+    "uuid": "^3.0.1",
     "yargs": "^6.3.0"
   },
   "devDependencies": {

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -1,7 +1,9 @@
 // @flow
 
 const _ = require('lodash')
-const Multihashing = require('multihashing')
+const Multihash = require('multihashes')
+const crypto = require('crypto')
+
 import type { Writable, Readable } from 'stream'
 import type { WriteStream } from 'tty'
 
@@ -81,9 +83,11 @@ function setEquals<T> (a: Set<T>, b: Set<T>): boolean {
  * @returns {string} a base58-encoded multihash string
  */
 function b58MultihashForBuffer (buf: Buffer): string {
-  return Multihashing.multihash.toB58String(
-    Multihashing(buf, 'sha2-256')
-  )
+  const hash = crypto.createHash('sha256')
+  hash.update(buf)
+
+  const mh = Multihash.encode(hash.digest(), 'sha2-256')
+  return Multihash.toB58String(mh)
 }
 
 /**
@@ -91,8 +95,8 @@ function b58MultihashForBuffer (buf: Buffer): string {
  */
 function isB58Multihash (str: string): boolean {
   try {
-    const h = Multihashing.multihash.fromB58String(str)
-    Multihashing.multihash.validate(h)
+    const h = Multihash.fromB58String(str)
+    Multihash.validate(h)
     return true
   } catch (err) {
     return false

--- a/src/peer/datastore.js
+++ b/src/peer/datastore.js
@@ -4,8 +4,7 @@ const { clone } = require('lodash')
 const Levelup = require('levelup')
 const uuid = require('uuid')
 const serialize = require('../metadata/serialize')
-const Multihashing = require('multihashing')
-const Multihash = require('multihashes')
+const { b58MultihashForBuffer } = require('../common/util')
 
 export type DatastoreOptions = {
   backend: 'memory', // just in-memory for now, expand to e.g. rocksdb
@@ -49,8 +48,7 @@ class Datastore {
       value = serialize.encode(value)
     }
 
-    const mh = Multihashing(value, 'sha2-256')
-    const key = Multihash.toB58String(mh)
+    const key = b58MultihashForBuffer(value)
 
     return new Promise((resolve, reject) => {
       this.db.put(key, value, {sync: true}, (err) => {


### PR DESCRIPTION
Since the synchronous `multihashing` module is [no longer recommended](https://github.com/multiformats/js-multihashing/issues/18#issuecomment-278742801), this removes our dependency on it.

We're were using it in the `b58MultihashForBuffer` helper (and `Datastore.put` which was written before the helper and can use it instead).

We are calling that helper in a couple of sync methods (like the constructor for `ExpandedSimpleStatementBody`), so I did the lazy thing and just did a synchronous implementation using node's `crypto.createHash` instead of trying to make everything async so we can use https://github.com/multiformats/js-multihashing-async which uses `crypto.createHash` on node anyway.
